### PR TITLE
54 gateway room registry and client room mapping

### DIFF
--- a/gateway/cmd/server/main.go
+++ b/gateway/cmd/server/main.go
@@ -26,6 +26,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", h.HandleWS)
+	mux.HandleFunc("/rooms", h.HandleCreateRoom)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/gateway/internal/client/client.go
+++ b/gateway/internal/client/client.go
@@ -1,28 +1,72 @@
 package client
 
-// Client represents a single connected WebSocket peer.
-//
-// Responsibilities:
-//   - Own the websocket.Conn
-//   - reads frames from the wire, decodes them
-//     into protocol.Message, forwards to the Room's ops channel
-//   - drains the send channel, writes frames to the wire
-//   - Handle graceful disconnect: close send channel → writePump exits →
-//     connection closed → Room is notified via leave channel
-//
-// A Client never talks to other Clients directly.
-// All cross-client communication goes through the Room's fan-out channel.
-//
-// The send channel is buffered (e.g. 256 messages).
-// If it fills up (slow reader), the client is dropped — no backpressure
-// allowed to stall the fan-out goroutine.
-//
-// Fields:
-//   ID       string            — unique per connection (uuid or random hex)
-//   RoomID   string            — which room this client belongs to
-//   IsHost   bool              — true if this client created the room
-//   conn     *websocket.Conn
-//   send     chan []byte        — outbound frame queue
-//   room     *room.Room        — back-reference for leave notification
+import (
+	"context"
 
-type Client struct{}
+	"github.com/coder/websocket"
+)
+
+const sendBufferSize = 256
+
+type Client struct {
+	ID     string
+	RoomID string
+	conn   *websocket.Conn
+	send   chan []byte
+}
+
+func New(id, roomID string, conn *websocket.Conn) *Client {
+	return &Client{
+		ID:     id,
+		RoomID: roomID,
+		conn:   conn,
+		send:   make(chan []byte, sendBufferSize),
+	}
+}
+
+func (c *Client) CloseSend() {
+	close(c.send)
+}
+
+// reads frames from the websocket and pushes each payload onto
+func (c *Client) ReadPump(ctx context.Context, ops chan<- []byte, leave chan<- *Client) {
+	defer func() {
+		select {
+		case leave <- c:
+		case <-ctx.Done():
+		}
+	}()
+
+	for {
+		_, data, err := c.conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		select {
+		case ops <- data:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// drains the send channel to the websocket until it is closed
+func (c *Client) WritePump(ctx context.Context) {
+	defer func() {
+		_ = c.conn.Close(websocket.StatusNormalClosure, "")
+	}()
+
+	for {
+		select {
+		case msg, ok := <-c.send:
+			if !ok {
+				return
+			}
+			if err := c.conn.Write(ctx, websocket.MessageBinary, msg); err != nil {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/gateway/internal/hub/export_test.go
+++ b/gateway/internal/hub/export_test.go
@@ -1,0 +1,13 @@
+package hub
+
+// Rooms returns a snapshot of current room IDs. Test-only: the
+// production code path never iterates the hub's registry.
+func (h *Hub) Rooms() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ids := make([]string, 0, len(h.rooms))
+	for id := range h.rooms {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -1,22 +1,116 @@
 package hub
 
 import (
-	"fmt"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"log"
 	"net/http"
+	"sync"
 
 	"github.com/coder/websocket"
 
+	"gateway/internal/client"
+	"gateway/internal/room"
 	"gateway/internal/wire"
 )
 
-type Hub struct{}
+const stagingOpsBuffer = 64
 
-func New() *Hub { return &Hub{} }
+type Hub struct {
+	mu    sync.Mutex
+	rooms map[string]*room.Room
+}
 
-func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
-	roomID := r.URL.Query().Get("room")
+func New() *Hub {
+	return &Hub{rooms: make(map[string]*room.Room)}
+}
+
+func (h *Hub) newRoomID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "00000000"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func (h *Hub) HandleCreateRoom(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := h.newRoomID()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"room_id": id})
+}
+
+func (h *Hub) getOrCreateRoom(id string) *room.Room {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r, ok := h.rooms[id]
+	if !ok {
+		r = room.New(id)
+		h.rooms[id] = r
+		go r.Run()
+	}
+	return r
+}
+
+func (h *Hub) discardIfStale(id string, r *room.Room) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.rooms[id] == r {
+		delete(h.rooms, id)
+	}
+}
+
+func (h *Hub) register(c *client.Client) *room.Room {
+	for {
+		r := h.getOrCreateRoom(c.RoomID)
+		if r.Join(c) {
+			return r
+		}
+		h.discardIfStale(c.RoomID, r)
+	}
+}
+
+func (h *Hub) unregister(c *client.Client, r *room.Room) {
+	r.Leave(c, func() { h.discardIfStale(r.ID, r) })
+}
+
+func readWSParams(w http.ResponseWriter, r *http.Request) (roomID, clientID string, ok bool) {
+	roomID = r.URL.Query().Get("room")
 	if roomID == "" {
 		http.Error(w, "missing ?room= parameter", http.StatusBadRequest)
+		return "", "", false
+	}
+	clientID = r.URL.Query().Get("client_id")
+	if clientID == "" {
+		http.Error(w, "missing ?client_id= parameter", http.StatusBadRequest)
+		return "", "", false
+	}
+	return roomID, clientID, true
+}
+
+func dispatchFrame(rm *room.Room, raw []byte, roomID, clientID string) {
+	payload, err := wire.DecodeOpFrame(raw)
+	if err != nil {
+		log.Printf("[gateway] drop frame room=%s client=%s: %v", roomID, clientID, err)
+		return
+	}
+	// TODO(T04): replace the silent drop with either back-pressure
+	// (block with a short timeout) or disconnecting the slow peer.
+	// Dropping ops silently diverges CRDT state on the recipients.
+	select {
+	case rm.Ops() <- payload:
+	default:
+		log.Printf("[gateway] ops buffer full room=%s; dropping frame", roomID)
+	}
+}
+
+func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
+	roomID, clientID, ok := readWSParams(w, r)
+	if !ok {
 		return
 	}
 
@@ -24,41 +118,33 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		InsecureSkipVerify: true,
 	})
 	if err != nil {
-		fmt.Printf("[gateway] upgrade failed for room %q: %v\n", roomID, err)
+		log.Printf("[gateway] upgrade failed room=%s: %v", roomID, err)
 		return
 	}
 
-	fmt.Printf("[gateway] client connected  room=%s\n", roomID)
-
-	ctx := r.Context()
+	c := client.New(clientID, roomID, conn)
+	rm := h.register(c)
+	log.Printf("[gateway] join  room=%s client=%s size=%d", roomID, clientID, rm.Size())
 	defer func() {
-		_ = conn.Close(websocket.StatusNormalClosure, "")
-		conn.CloseNow()
+		h.unregister(c, rm)
+		log.Printf("[gateway] leave room=%s client=%s", roomID, clientID)
 	}()
 
+	ctx := r.Context()
+	ops := make(chan []byte, stagingOpsBuffer)
+	leave := make(chan *client.Client, 1)
+
+	go c.WritePump(ctx)
+	go c.ReadPump(ctx, ops, leave)
+
 	for {
-		msgType, msg, err := conn.Read(ctx)
-		if err != nil {
-			fmt.Printf("[gateway] client disconnected room=%s: %v\n", roomID, err)
+		select {
+		case raw := <-ops:
+			dispatchFrame(rm, raw, roomID, clientID)
+		case <-leave:
 			return
-		}
-
-		switch msgType {
-		case websocket.MessageText:
-			fmt.Printf("[gateway] text  room=%s  %s\n", roomID, msg)
-
-		case websocket.MessageBinary:
-			payload, err := wire.DecodeOpFrame(msg)
-			if err != nil {
-				fmt.Printf("[gateway] drop frame room=%s: %v\n", roomID, err)
-				continue
-			}
-			fmt.Printf("[gateway] op    room=%s  payload=%d bytes\n", roomID, len(payload))
-
-			if err := conn.Write(ctx, msgType, msg); err != nil {
-				fmt.Printf("[gateway] write error room=%s: %v\n", roomID, err)
-				return
-			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/gateway/internal/hub/hub_test.go
+++ b/gateway/internal/hub/hub_test.go
@@ -1,0 +1,190 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"gateway/internal/wire"
+)
+
+func newTestServer(t *testing.T) (*httptest.Server, *Hub) {
+	t.Helper()
+	h := New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", h.HandleWS)
+	mux.HandleFunc("/rooms", h.HandleCreateRoom)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, h
+}
+
+func wsURL(base, room, clientID string) string {
+	return strings.Replace(base, "http://", "ws://", 1) +
+		"/ws?room=" + room + "&client_id=" + clientID
+}
+
+func dial(t *testing.T, url string) *websocket.Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", url, err)
+	}
+	return c
+}
+
+func TestHub_PostRoomsReturnsFreshID(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	var ids []string
+	for i := 0; i < 2; i++ {
+		resp, err := http.Post(srv.URL+"/rooms", "application/json", nil)
+		if err != nil {
+			t.Fatalf("POST /rooms: %v", err)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		resp.Body.Close()
+		id := body["room_id"]
+		if !regexp.MustCompile(`^[0-9a-f]{8}$`).MatchString(id) {
+			t.Fatalf("room_id=%q, want 8 hex chars", id)
+		}
+		ids = append(ids, id)
+	}
+	if ids[0] == ids[1] {
+		t.Fatalf("IDs collided: %s", ids[0])
+	}
+}
+
+func TestHub_PostRoomsRejectsGet(t *testing.T) {
+	srv, _ := newTestServer(t)
+	resp, err := http.Get(srv.URL + "/rooms")
+	if err != nil {
+		t.Fatalf("GET /rooms: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d, want 405", resp.StatusCode)
+	}
+}
+
+func TestHub_RejectsMissingQuery(t *testing.T) {
+	srv, _ := newTestServer(t)
+	for _, path := range []string{"/ws", "/ws?room=r", "/ws?client_id=c"} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("%s: status=%d, want 400", path, resp.StatusCode)
+		}
+	}
+}
+
+func TestHub_TwoClientsSameRoomShareSet(t *testing.T) {
+	srv, h := newTestServer(t)
+	a := dial(t, wsURL(srv.URL, "shared", "alice"))
+	defer a.Close(websocket.StatusNormalClosure, "")
+	b := dial(t, wsURL(srv.URL, "shared", "bob"))
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(h.Rooms()) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if rooms := h.Rooms(); len(rooms) != 1 || rooms[0] != "shared" {
+		t.Fatalf("Rooms=%v, want [shared]", rooms)
+	}
+}
+
+func TestHub_DisconnectRemovesClient(t *testing.T) {
+	srv, h := newTestServer(t)
+	a := dial(t, wsURL(srv.URL, "ephemeral", "alice"))
+
+	registerDeadline := time.Now().Add(time.Second)
+	for time.Now().Before(registerDeadline) && len(h.Rooms()) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(h.Rooms()) != 1 {
+		t.Fatalf("room not registered")
+	}
+
+	_ = a.Close(websocket.StatusNormalClosure, "bye")
+
+	disconnectDeadline := time.Now().Add(time.Second)
+	for time.Now().Before(disconnectDeadline) && len(h.Rooms()) != 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := h.Rooms(); len(got) != 0 {
+		t.Fatalf("Rooms=%v, want empty after disconnect", got)
+	}
+}
+
+func TestHub_RoomsIsolated(t *testing.T) {
+	srv, _ := newTestServer(t)
+	a := dial(t, wsURL(srv.URL, "x", "a"))
+	defer a.Close(websocket.StatusNormalClosure, "")
+	c := dial(t, wsURL(srv.URL, "y", "c"))
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if err := a.Write(ctx, websocket.MessageBinary, wire.EncodeOpFrame([]byte("hello"))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer readCancel()
+	_, _, err := c.Read(readCtx)
+	if err == nil {
+		t.Fatal("client in room y received a frame from room x — rooms are not isolated")
+	}
+}
+
+func TestHub_ConcurrentJoinsSameRoom(t *testing.T) {
+	srv, h := newTestServer(t)
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+	conns := make(chan *websocket.Conn, n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			cid := fmt.Sprintf("c%d", i)
+			conns <- dial(t, wsURL(srv.URL, "race", cid))
+		}(i)
+	}
+	wg.Wait()
+	close(conns)
+	for c := range conns {
+		defer c.Close(websocket.StatusNormalClosure, "")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(h.Rooms()) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if rooms := h.Rooms(); len(rooms) != 1 || rooms[0] != "race" {
+		t.Fatalf("Rooms=%v, want [race]", rooms)
+	}
+}

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -1,27 +1,79 @@
 package room
 
-// Room represents one collaborative editing session.
-// Every unique room ID gets exactly one Room instance.
-//
-// Responsibilities:
-//   - Track which Client is the host (first joiner, or explicit claim)
-//   - Track all connected peer Clients
-//   - Run a single fan-out goroutine: reads from ops channel, writes to all peers
-//   - Handle join / leave events
-//   - Assign a monotonically increasing sequence number to every forwarded op
-//     so late-joining peers can detect gaps and request replay
-//   - Forward a "sync request" from a new peer directly to the host,
-//     so the host can respond with a full document snapshot
-//
-// The Room never deserializes op payloads. It treats them as opaque []byte.
-// Op ordering and conflict resolution are purely the CRDT library's job.
-//
-// Concurrency model:
-//   - One goroutine per Room (the fan-out loop), started in Run()
-//   - Join/Leave send signals over channels into that goroutine
-//   - No locks needed: all state mutation happens inside the fan-out goroutine
-//
-// Lifecycle:
-//   hub.GetOrCreate → room.Run() in a goroutine → room empties → signals hub to delete
+import (
+	"sync"
 
-type Room struct{}
+	"gateway/internal/client"
+)
+
+const opsBufferSize = 256
+
+type Room struct {
+	ID string
+
+	mu      sync.Mutex
+	clients map[*client.Client]struct{}
+	closed  bool
+
+	ops  chan []byte
+	done chan struct{}
+}
+
+func New(id string) *Room {
+	return &Room{
+		ID:      id,
+		clients: make(map[*client.Client]struct{}),
+		ops:     make(chan []byte, opsBufferSize),
+		done:    make(chan struct{}),
+	}
+}
+
+func (r *Room) Join(c *client.Client) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	r.clients[c] = struct{}{}
+	return true
+}
+
+func (r *Room) Leave(c *client.Client, onEmpty func()) {
+	r.mu.Lock()
+	if _, ok := r.clients[c]; !ok {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.clients, c)
+	c.CloseSend()
+	empty := len(r.clients) == 0
+	if empty {
+		r.closed = true
+		close(r.done)
+	}
+	r.mu.Unlock()
+
+	if empty && onEmpty != nil {
+		onEmpty()
+	}
+}
+
+func (r *Room) Ops() chan<- []byte { return r.ops }
+
+func (r *Room) Size() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.clients)
+}
+
+func (r *Room) Run() {
+	for {
+		select {
+		case <-r.done:
+			return
+		case payload := <-r.ops:
+			// TODO(T04): fan out to every client except sender
+			_ = payload
+		}
+	}
+}

--- a/gateway/internal/room/room_test.go
+++ b/gateway/internal/room/room_test.go
@@ -1,0 +1,94 @@
+package room
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"gateway/internal/client"
+)
+
+func TestRoom_JoinLeaveTriggersOnEmpty(t *testing.T) {
+	r := New("room-1")
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	a := client.New("a", "room-1", nil)
+	b := client.New("b", "room-1", nil)
+	if !r.Join(a) || !r.Join(b) {
+		t.Fatal("join rejected by fresh room")
+	}
+	if got := r.Size(); got != 2 {
+		t.Fatalf("Size=%d, want 2", got)
+	}
+
+	var emptied sync.WaitGroup
+	emptied.Add(1)
+	r.Leave(a, func() { t.Fatal("onEmpty fired with 1 member left") })
+	r.Leave(b, func() { emptied.Done() })
+	emptied.Wait()
+
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after room emptied")
+	}
+}
+
+func TestRoom_SendToEmptyIsNoop(t *testing.T) {
+	r := New("room-2")
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	a := client.New("a", "room-2", nil)
+	r.Join(a)
+
+	r.Ops() <- []byte{0x00, 0xDE, 0xAD}
+	r.Ops() <- []byte{}
+
+	r.Leave(a, nil)
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after last client left")
+	}
+}
+
+func TestRoom_DoubleLeaveIsSilent(t *testing.T) {
+	r := New("room-3")
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	a := client.New("a", "room-3", nil)
+	r.Join(a)
+
+	calls := 0
+	r.Leave(a, func() { calls++ })
+	r.Leave(a, func() { calls++ })
+	if calls != 1 {
+		t.Fatalf("onEmpty fired %d times, want exactly 1", calls)
+	}
+
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return")
+	}
+}
+
+func TestRoom_JoinAfterCloseIsRejected(t *testing.T) {
+	r := New("room-4")
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	a := client.New("a", "room-4", nil)
+	r.Join(a)
+	r.Leave(a, nil)
+
+	b := client.New("b", "room-4", nil)
+	if r.Join(b) {
+		t.Fatal("Join succeeded on closed room")
+	}
+
+	<-runDone
+}

--- a/tauri-app/src-tauri/src/session.rs
+++ b/tauri-app/src-tauri/src/session.rs
@@ -50,7 +50,7 @@ pub fn start_host_session(app: AppHandle) -> Result<(), String> {
         *role = AppRole::Starting;
     }
 
-    tunnel::launch(app, tunnel::generate_room_id());
+    tunnel::launch(app);
     Ok(())
 }
 

--- a/tauri-app/src-tauri/src/state/ws_state.rs
+++ b/tauri-app/src-tauri/src/state/ws_state.rs
@@ -96,15 +96,4 @@ impl WsState {
             _ => Err(WsError::NotConnected),
         }
     }
-
-    pub async fn send(&self, msg: Message) -> Result<(), WsError> {
-        let arc = {
-            let guard = self.write_tx.read().unwrap();
-            guard.as_ref().ok_or(WsError::NotConnected)?.clone()
-        };
-
-        arc.send(msg)
-            .await
-            .map_err(|_| WsError::SendFailed("writer task has exited".into()))
-    }
 }

--- a/tauri-app/src-tauri/src/tunnel.rs
+++ b/tauri-app/src-tauri/src/tunnel.rs
@@ -4,24 +4,21 @@ use crate::session::{
 };
 use crate::state::appstate::{AppRole, AppState};
 use crate::state::ws_state::WsState;
-use rand::Rng;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-pub fn generate_room_id() -> String {
-    format!("{:08x}", rand::thread_rng().gen::<u32>())
-}
-
-pub fn launch(app: AppHandle, room_id: String) {
+pub fn launch(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        if let Err(msg) = run_gateway(&app, &room_id).await {
+        if let Err(msg) = run_gateway(&app).await {
             emit_error(&app, msg);
         }
     });
 }
 
-async fn run_gateway(app: &AppHandle, room_id: &str) -> Result<(), String> {
+async fn run_gateway(app: &AppHandle) -> Result<(), String> {
     let (mut rx, child) = app
         .shell()
         .sidecar("peercode-gateway")
@@ -46,7 +43,8 @@ async fn run_gateway(app: &AppHandle, room_id: &str) -> Result<(), String> {
             let line = String::from_utf8_lossy(&bytes);
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(line.trim()) {
                 if let Some(port) = json.get("port").and_then(|v| v.as_u64()).map(|v| v as u16) {
-                    on_gateway_ready(app, port, room_id).await;
+                    let room_id = fetch_room_id(port).await?;
+                    on_gateway_ready(app, port, &room_id).await;
                     println!("Gateway ready");
                     tauri::async_runtime::spawn(pipe_gateway_logs(rx));
                     return Ok(());
@@ -132,25 +130,17 @@ fn run_cloudflared(app: AppHandle, port: u16, room_id: String) {
                         },
                     );
 
-                    let ws_url = format!("ws://127.0.0.1:{port}/ws?room={room_id}");
+                    let host_client_id = {
+                        let state = app.state::<AppState>();
+                        let doc = state.document.lock().unwrap();
+                        doc.client_id.value
+                    };
+                    let local_ws_url = format!(
+                        "ws://127.0.0.1:{port}/ws?room={room_id}&client_id={host_client_id}"
+                    );
                     let ws = app.state::<WsState>();
-                    match ws.connect(&ws_url, room_id.clone()).await {
-                        Err(e) => {
-                            eprintln!("[ws] local connection failed (session still running): {e}")
-                        }
-                        Ok(()) => {
-                            let test_msg = format!(
-                                r#"{{"type":"ping","room":"{room_id}","client_id":"tauri-host"}}"#
-                            );
-                            if let Err(e) = ws
-                                .send(tokio_tungstenite::tungstenite::Message::Text(
-                                    test_msg.into(),
-                                ))
-                                .await
-                            {
-                                eprintln!("[ws] test send failed: {e}");
-                            }
-                        }
+                    if let Err(e) = ws.connect(&local_ws_url, room_id.clone()).await {
+                        eprintln!("[ws] local connection failed (session still running): {e}");
                     }
                     return;
                 }
@@ -195,6 +185,62 @@ fn store_public_url(app: &AppHandle, url: &str) {
     {
         *stored = Some(url.to_string());
     }
+}
+
+const FETCH_ROOM_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn fetch_room_id(port: u16) -> Result<String, String> {
+    tokio::time::timeout(FETCH_ROOM_TIMEOUT, fetch_room_id_inner(port))
+        .await
+        .map_err(|_| {
+            format!(
+                "gateway /rooms: timed out after {}s",
+                FETCH_ROOM_TIMEOUT.as_secs()
+            )
+        })?
+}
+
+async fn fetch_room_id_inner(port: u16) -> Result<String, String> {
+    let response = gateway_http_post_empty(port, "/rooms").await?;
+    parse_room_id_response(&response)
+}
+
+async fn gateway_http_post_empty(port: u16, path: &str) -> Result<Vec<u8>, String> {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .map_err(|e| format!("connect gateway {path}: {e}"))?;
+
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|e| format!("write {path}: {e}"))?;
+
+    let mut buf = Vec::with_capacity(256);
+    stream
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|e| format!("read {path}: {e}"))?;
+    Ok(buf)
+}
+
+fn parse_room_id_response(response: &[u8]) -> Result<String, String> {
+    let text = String::from_utf8_lossy(response);
+    let body_idx = text
+        .find("\r\n\r\n")
+        .ok_or_else(|| "gateway /rooms: malformed response (no body)".to_string())?
+        + 4;
+    let body = text[body_idx..].trim();
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("gateway /rooms: invalid JSON: {e}"))?;
+    parsed
+        .get("room_id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "gateway /rooms: response missing room_id".to_string())
 }
 
 async fn pipe_gateway_logs(mut rx: tokio::sync::mpsc::Receiver<CommandEvent>) {

--- a/tauri-app/src-tauri/src/ws_management/ws_types.rs
+++ b/tauri-app/src-tauri/src/ws_management/ws_types.rs
@@ -27,7 +27,6 @@ pub enum WsError {
     Timeout { url: String, secs: u64 },
     Handshake { url: String, cause: String },
     NotConnected,
-    SendFailed(String),
     Cancelled,
 }
 
@@ -44,7 +43,6 @@ impl Display for WsError {
                 write!(f, "WebSocket connect to {url} failed: {cause}")
             }
             WsError::NotConnected => write!(f, "WebSocket is not connected"),
-            WsError::SendFailed(e) => write!(f, "WebSocket send failed: {e}"),
             WsError::Cancelled => write!(f, "WebSocket connection cancelled before handshake"),
         }
     }


### PR DESCRIPTION
Implements T03. Hub owns rooms under a sync.Mutex; each Room runs in its
own goroutine and exits via a done channel so HandleWS can send to      
r.Ops() without racing the close. Client has buffered send + Read/Write 
pumps ready for T04 fan-out. POST /rooms mints an 8-hex ID via          
crypto/rand so the host no longer generates room IDs locally.           
                                                                        
HandleWS now requires both ?room= and ?client_id= query params; frames  
are decoded via wire.DecodeOpFrame and forwarded to the room (fan-out   
itself is TODO(T04)).                                                   
                               
Host no longer generates room IDs locally; after the gateway reports its
port, launch() POSTs /rooms and uses the returned ID. The local loopback
ws URL now carries &client_id=<host> so the gateway can register the    
host the same way it registers guests.                                  
                                                                        
fetch_room_id is split into gateway_http_post_empty (IO) and            
parse_room_id_response (pure parser), wrapped in a 5s timeout so a      
stalled gateway can't hang host start-up.                               
                                                                        
Removes dead WsState::send and WsError::SendFailed (re-added by T10     
when actually needed).  