### PR TITLE
implement op fan-out

### DIFF
--- a/gateway/internal/client/client.go
+++ b/gateway/internal/client/client.go
@@ -28,6 +28,28 @@ func (c *Client) CloseSend() {
 	close(c.send)
 }
 
+// returns false without blocking if the send buffer is full
+func (c *Client) Send(data []byte) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	select {
+	case c.send <- data:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Client) ForceClose() {
+	if c.conn == nil {
+		return
+	}
+	go c.conn.Close(websocket.StatusPolicyViolation, "slow consumer")
+}
+
 // reads frames from the websocket and pushes each payload onto
 func (c *Client) ReadPump(ctx context.Context, ops chan<- []byte, leave chan<- *Client) {
 	defer func() {

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/coder/websocket"
 
@@ -92,19 +93,26 @@ func readWSParams(w http.ResponseWriter, r *http.Request) (roomID, clientID stri
 	return roomID, clientID, true
 }
 
-func dispatchFrame(rm *room.Room, raw []byte, roomID, clientID string) {
-	payload, err := wire.DecodeOpFrame(raw)
-	if err != nil {
-		log.Printf("[gateway] drop frame room=%s client=%s: %v", roomID, clientID, err)
+func dispatchFrame(rm *room.Room, sender *client.Client, raw []byte) {
+	if _, err := wire.DecodeOpFrame(raw); err != nil {
+		log.Printf("[gateway] drop frame room=%s client=%s: %v", sender.RoomID, sender.ID, err)
 		return
 	}
-	// TODO(T04): replace the silent drop with either back-pressure
-	// (block with a short timeout) or disconnecting the slow peer.
-	// Dropping ops silently diverges CRDT state on the recipients.
+
+	msg := room.BroadcastMsg{Sender: sender, Data: raw}
+
 	select {
-	case rm.Ops() <- payload:
+	case rm.Ops() <- msg:
+		return
 	default:
-		log.Printf("[gateway] ops buffer full room=%s; dropping frame", roomID)
+	}
+
+	t := time.NewTimer(100 * time.Millisecond)
+	defer t.Stop()
+	select {
+	case rm.Ops() <- msg:
+	case <-t.C:
+		log.Printf("[gateway] ops buffer full room=%s client=%s; dropping frame", sender.RoomID, sender.ID)
 	}
 }
 
@@ -140,7 +148,7 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case raw := <-ops:
-			dispatchFrame(rm, raw, roomID, clientID)
+			dispatchFrame(rm, c, raw)
 		case <-leave:
 			return
 		case <-ctx.Done():

--- a/gateway/internal/hub/hub_test.go
+++ b/gateway/internal/hub/hub_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -186,5 +187,121 @@ func TestHub_ConcurrentJoinsSameRoom(t *testing.T) {
 	}
 	if rooms := h.Rooms(); len(rooms) != 1 || rooms[0] != "race" {
 		t.Fatalf("Rooms=%v, want [race]", rooms)
+	}
+}
+
+func TestHub_FanOut_SenderExcluded(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	a := dial(t, wsURL(srv.URL, "fanout", "mate"))
+	defer a.Close(websocket.StatusNormalClosure, "")
+	b := dial(t, wsURL(srv.URL, "fanout", "gendi"))
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	time.Sleep(50 * time.Millisecond)
+
+	ctx := context.Background()
+	payload := wire.EncodeOpFrame([]byte("hello"))
+	if err := a.Write(ctx, websocket.MessageBinary, payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	readCtx, readCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer readCancel()
+	_, data, err := b.Read(readCtx)
+	if err != nil {
+		t.Fatalf("gendi read: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("gendi got %x, want %x", data, payload)
+	}
+
+	noEchoCtx, noEchoCancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer noEchoCancel()
+	_, _, err = a.Read(noEchoCtx)
+	if err == nil {
+		t.Fatal("mate received echo")
+	}
+}
+
+func TestHub_FanOut_ThreeClients(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	a := dial(t, wsURL(srv.URL, "trio", "mate"))
+	defer a.Close(websocket.StatusNormalClosure, "")
+	b := dial(t, wsURL(srv.URL, "trio", "gendi"))
+	defer b.Close(websocket.StatusNormalClosure, "")
+	c := dial(t, wsURL(srv.URL, "trio", "gela"))
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	time.Sleep(50 * time.Millisecond)
+
+	ctx := context.Background()
+	payload := wire.EncodeOpFrame([]byte("broadcast"))
+	if err := a.Write(ctx, websocket.MessageBinary, payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for _, pair := range []struct {
+		name string
+		conn *websocket.Conn
+	}{{"gendi", b}, {"gela", c}} {
+		readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		_, data, err := pair.conn.Read(readCtx)
+		cancel()
+		if err != nil {
+			t.Fatalf("%s read: %v", pair.name, err)
+		}
+		if !bytes.Equal(data, payload) {
+			t.Fatalf("%s got %x, want %x", pair.name, data, payload)
+		}
+	}
+
+	noEchoCtx, noEchoCancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer noEchoCancel()
+	_, _, err := a.Read(noEchoCtx)
+	if err == nil {
+		t.Fatal("mate received echo")
+	}
+}
+
+func BenchmarkHub_FanOut_1000Ops(b *testing.B) {
+	h := New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", h.HandleWS)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := context.Background()
+
+	sender, _, err := websocket.Dial(ctx, wsURL(srv.URL, "bench", "sender"), nil)
+	if err != nil {
+		b.Fatalf("dial sender: %v", err)
+	}
+	defer sender.Close(websocket.StatusNormalClosure, "")
+
+	receiver, _, err := websocket.Dial(ctx, wsURL(srv.URL, "bench", "receiver"), nil)
+	if err != nil {
+		b.Fatalf("dial receiver: %v", err)
+	}
+	defer receiver.Close(websocket.StatusNormalClosure, "")
+
+	time.Sleep(50 * time.Millisecond)
+
+	payload := wire.EncodeOpFrame([]byte("op"))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1000; j++ {
+			if err := sender.Write(ctx, websocket.MessageBinary, payload); err != nil {
+				b.Fatalf("write: %v", err)
+			}
+			readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			_, _, err := receiver.Read(readCtx)
+			cancel()
+			if err != nil {
+				b.Fatalf("read: %v", err)
+			}
+		}
 	}
 }

--- a/gateway/internal/protocol/protocol.go
+++ b/gateway/internal/protocol/protocol.go
@@ -35,4 +35,10 @@ const (
 	MsgPong     = "pong"
 )
 
-type Message struct{}
+type Message struct {
+	Type     string `json:"type"`
+	Room     string `json:"room"`
+	ClientID string `json:"client_id"`
+	Seq      uint64 `json:"seq"`
+	Payload  string `json:"payload"`
+}

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -1,12 +1,18 @@
 package room
 
 import (
+	"log"
 	"sync"
 
 	"gateway/internal/client"
 )
 
 const opsBufferSize = 256
+
+type BroadcastMsg struct {
+	Sender *client.Client
+	Data   []byte
+}
 
 type Room struct {
 	ID string
@@ -15,7 +21,7 @@ type Room struct {
 	clients map[*client.Client]struct{}
 	closed  bool
 
-	ops  chan []byte
+	ops  chan BroadcastMsg
 	done chan struct{}
 }
 
@@ -23,7 +29,7 @@ func New(id string) *Room {
 	return &Room{
 		ID:      id,
 		clients: make(map[*client.Client]struct{}),
-		ops:     make(chan []byte, opsBufferSize),
+		ops:     make(chan BroadcastMsg, opsBufferSize),
 		done:    make(chan struct{}),
 	}
 }
@@ -58,7 +64,7 @@ func (r *Room) Leave(c *client.Client, onEmpty func()) {
 	}
 }
 
-func (r *Room) Ops() chan<- []byte { return r.ops }
+func (r *Room) Ops() chan<- BroadcastMsg { return r.ops }
 
 func (r *Room) Size() int {
 	r.mu.Lock()
@@ -71,9 +77,22 @@ func (r *Room) Run() {
 		select {
 		case <-r.done:
 			return
-		case payload := <-r.ops:
-			// TODO(T04): fan out to every client except sender
-			_ = payload
+		case msg := <-r.ops:
+			r.mu.Lock()
+			targets := make([]*client.Client, 0, len(r.clients))
+			for c := range r.clients {
+				if c != msg.Sender {
+					targets = append(targets, c)
+				}
+			}
+			r.mu.Unlock()
+
+			for _, c := range targets {
+				if !c.Send(msg.Data) {
+					log.Printf("[room] %s: disconnecting slow client %s", r.ID, c.ID)
+					c.ForceClose()
+				}
+			}
 		}
 	}
 }

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -76,23 +76,39 @@ func (r *Room) Run() {
 	for {
 		select {
 		case <-r.done:
+			r.drain()
 			return
 		case msg := <-r.ops:
-			r.mu.Lock()
-			targets := make([]*client.Client, 0, len(r.clients))
-			for c := range r.clients {
-				if c != msg.Sender {
-					targets = append(targets, c)
-				}
-			}
-			r.mu.Unlock()
+			r.broadcast(msg)
+		}
+	}
+}
 
-			for _, c := range targets {
-				if !c.Send(msg.Data) {
-					log.Printf("[room] %s: disconnecting slow client %s", r.ID, c.ID)
-					c.ForceClose()
-				}
-			}
+func (r *Room) broadcast(msg BroadcastMsg) {
+	r.mu.Lock()
+	targets := make([]*client.Client, 0, len(r.clients))
+	for c := range r.clients {
+		if c != msg.Sender {
+			targets = append(targets, c)
+		}
+	}
+	r.mu.Unlock()
+
+	for _, c := range targets {
+		if !c.Send(msg.Data) {
+			log.Printf("[room] %s: disconnecting slow client %s", r.ID, c.ID)
+			c.ForceClose()
+		}
+	}
+}
+
+func (r *Room) drain() {
+	for {
+		select {
+		case msg := <-r.ops:
+			r.broadcast(msg)
+		default:
+			return
 		}
 	}
 }

--- a/gateway/internal/room/room_test.go
+++ b/gateway/internal/room/room_test.go
@@ -43,8 +43,8 @@ func TestRoom_SendToEmptyIsNoop(t *testing.T) {
 	a := client.New("a", "room-2", nil)
 	r.Join(a)
 
-	r.Ops() <- []byte{0x00, 0xDE, 0xAD}
-	r.Ops() <- []byte{}
+	r.Ops() <- BroadcastMsg{Sender: a, Data: []byte{0x00, 0xDE, 0xAD}}
+	r.Ops() <- BroadcastMsg{Sender: a, Data: []byte{}}
 
 	r.Leave(a, nil)
 	select {


### PR DESCRIPTION
- add BroadcastMsg{Sender, Data} so Run() can exclude the sender
  from fan-out without comparing string IDs
- implement Room.Run() fan-out: snapshot clients under lock, release,
  then Send() to each peer; ForceClose() on full buffer
- add Client.Send() with panic recovery for the CloseSend() race window
- add Client.ForceClose() running ws close in a background goroutine
  so a slow peer can't stall the fan-out loop
- fill in protocol.Message struct

Closes #40 