### PR TITLE
Implement Session leaving and ending 

### DIFF
--- a/build/make/build.mk
+++ b/build/make/build.mk
@@ -33,13 +33,13 @@ MOLD_EXISTS := $(shell command -v mold >/dev/null 2>&1 && echo yes || echo no)
 RUSTFLAGS ?= $(if $(filter yes,$(MOLD_EXISTS)),-C link-arg=-fuse-ld=mold,)
 
 dev: install-rust-dev-tools $(CLOUDFLARED_BIN) $(GATEWAY_BIN)
-	cd tauri-app && RUSTC_WRAPPER=$(RUSTC_WRAPPER) RUSTFLAGS="$(RUSTFLAGS)" VITE_PORT=$(PORT) npx tauri dev --config '{"build":{"devUrl":"http://localhost:$(PORT)"}}'
+	cd tauri-app && RUSTC_WRAPPER=$(RUSTC_WRAPPER) RUSTFLAGS="$(RUSTFLAGS)" VITE_PORT=$(PORT) VITE_DEV_FEATURES=true npx tauri dev --config '{"build":{"devUrl":"http://localhost:$(PORT)"}}'
 
 $(FRONTEND_BUILD_OUT): $(FRONTEND_BUILD_INPUTS)
 	cd tauri-app && npm run build
 
 $(RUST_RELEASE_BIN): $(RUST_RELEASE_INPUTS)
-	cd tauri-app && npm run tauri build -- --no-bundle
+	cd tauri-app/src-tauri && RUSTC_WRAPPER=$(RUSTC_WRAPPER) RUSTFLAGS="$(RUSTFLAGS)" cargo build --release
 
 prod-build: $(CLOUDFLARED_BIN) $(GATEWAY_BIN) $(FRONTEND_BUILD_OUT) $(RUST_RELEASE_BIN)
 

--- a/crdt-core/src/wire.rs
+++ b/crdt-core/src/wire.rs
@@ -7,6 +7,8 @@ use std::fmt;
 
 pub const OP_PREFIX: u8 = 0x00;
 pub const SNAPSHOT_PREFIX: u8 = 0x01;
+pub const PREFIX_CONTROL: u8 = 0x02;
+pub const CONTROL_SESSION_ENDED: u8 = 0x01;
 
 #[derive(Debug, Clone, PartialEq, Eq, bitcode::Encode, bitcode::Decode)]
 pub struct WireBlock {

--- a/crdt-core/src/wire/protocol_drift_tests.rs
+++ b/crdt-core/src/wire/protocol_drift_tests.rs
@@ -1,9 +1,12 @@
-use super::{OP_PREFIX, SNAPSHOT_PREFIX};
+use super::{CONTROL_SESSION_ENDED, OP_PREFIX, PREFIX_CONTROL, SNAPSHOT_PREFIX};
 
 #[test]
 fn prefix_constants_match_go_mirror() {
     const GO_PREFIX_OP: u8 = 0x00;
     const GO_PREFIX_SNAPSHOT: u8 = 0x01;
+
+    const GO_PREFIX_CONTROL: u8 = 0x02;
+    const GO_CONTROL_SESSION_ENDED: u8 = 0x01;
 
     assert_eq!(
         OP_PREFIX, GO_PREFIX_OP,
@@ -12,5 +15,13 @@ fn prefix_constants_match_go_mirror() {
     assert_eq!(
         SNAPSHOT_PREFIX, GO_PREFIX_SNAPSHOT,
         "SNAPSHOT_PREFIX drifted from gateway/internal/wire::PrefixSnapshot"
+    );
+    assert_eq!(
+        PREFIX_CONTROL, GO_PREFIX_CONTROL,
+        "PREFIX_CONTROL drifted from gateway/internal/wire::PREFIX_CONTROL"
+    );
+    assert_eq!(
+        CONTROL_SESSION_ENDED, GO_CONTROL_SESSION_ENDED,
+        "CONTROL_SESSION_ENDED drifted from gateway/internal/wire::CONTROL_SESSION_ENDED"
     );
 }

--- a/gateway/cmd/server/main.go
+++ b/gateway/cmd/server/main.go
@@ -36,6 +36,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", h.HandleWS)
 	mux.HandleFunc("/rooms", h.HandleCreateRoom)
+	mux.HandleFunc("/end-session", h.HandleEndSession)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,5 +1,5 @@
 module gateway
 
-go 1.25.9
+go 1.25.10
 
 require github.com/coder/websocket v1.8.14

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -156,6 +156,30 @@ func dispatchFrame(rm *room.Room, sender *client.Client, raw []byte) {
 	}
 }
 
+func (h *Hub) HandleEndSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	roomID := r.URL.Query().Get("room")
+	if roomID == "" {
+		http.Error(w, "missing ?room= parameter", http.StatusBadRequest)
+		return
+	}
+	h.mu.Lock()
+	rm, ok := h.rooms[roomID]
+	h.mu.Unlock()
+	if !ok {
+		slog.Warn("end-session: room not found", "room_id", roomID)
+		http.Error(w, "room not found", http.StatusNotFound)
+		return
+	}
+	frame := wire.EncodeControlFrame(wire.ControlSessionEnded)
+	rm.BroadcastAll(frame)
+	slog.Info("end-session: session-ended broadcast sent", "room_id", roomID)
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 	roomID, clientID, ok := readWSParams(w, r)
 	if !ok {

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -93,14 +93,7 @@ func (r *Room) Run() {
 }
 
 func (r *Room) broadcast(msg BroadcastMsg) {
-	r.mu.Lock()
-	targets := make([]*client.Client, 0, len(r.clients))
-	for c := range r.clients {
-		if c != msg.Sender {
-			targets = append(targets, c)
-		}
-	}
-	r.mu.Unlock()
+	targets := r.getPeers(msg.Sender)
 
 	slog.Debug(
 		"broadcast dispatch prepared",
@@ -109,9 +102,30 @@ func (r *Room) broadcast(msg BroadcastMsg) {
 		"targets", len(targets),
 		"bytes", len(msg.Data),
 	)
+	r.sendToPeers(targets, msg.Data, "disconnecting slow client")
+}
+
+func (r *Room) BroadcastAll(data []byte) {
+	targets := r.getPeers(nil)
+	r.sendToPeers(targets, data, "slow client during BroadcastAll; force-closing")
+}
+
+func (r *Room) getPeers(exclude *client.Client) []*client.Client {
+	r.mu.Lock()
+	targets := make([]*client.Client, 0, len(r.clients))
+	for c := range r.clients {
+		if exclude == nil || c != exclude {
+			targets = append(targets, c)
+		}
+	}
+	r.mu.Unlock()
+	return targets
+}
+
+func (r *Room) sendToPeers(targets []*client.Client, data []byte, slowClientLogMsg string) {
 	for _, c := range targets {
-		if !c.Send(msg.Data) {
-			slog.Warn("disconnecting slow client", "room_id", r.ID, "client_id", c.ID)
+		if !c.Send(data) {
+			slog.Warn(slowClientLogMsg, "room_id", r.ID, "client_id", c.ID)
 			c.ForceClose()
 		}
 	}

--- a/gateway/internal/wire/wire.go
+++ b/gateway/internal/wire/wire.go
@@ -8,7 +8,16 @@ import (
 const (
 	PrefixOp       byte = 0x00
 	PrefixSnapshot byte = 0x01
+	PrefixControl  byte = 0x02
 )
+
+const (
+	ControlSessionEnded byte = 0x01
+)
+
+func EncodeControlFrame(controlType byte) []byte {
+	return []byte{PrefixControl, controlType}
+}
 
 var (
 	ErrEmptyFrame           = errors.New("wire: empty frame")

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -3369,7 +3369,7 @@
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
+        "postcss": "^8.5.10",
         "rollup": "^4.34.9",
         "tinyglobby": "^0.2.13"
       },

--- a/tauri-app/src-tauri/src/debug/document_logger.rs
+++ b/tauri-app/src-tauri/src/debug/document_logger.rs
@@ -1,22 +1,23 @@
 use crate::state::appstate::AppState;
 use log::info;
 use std::sync::atomic::Ordering;
-use std::thread;
 use std::time::Duration;
 use tauri::Manager;
 
 #[cfg(debug_assertions)]
 pub fn spawn_linked_list_logger(app_handle: tauri::AppHandle) {
-    thread::spawn::<_, ()>(move || loop {
-        let state = app_handle.state::<AppState>();
-
-        if state.crdt_logging_enabled.load(Ordering::Relaxed) {
-            let text = {
-                let document = state.document.lock().unwrap();
-                document.debug_linked_list()
-            };
-            info!("CRDT linked list: {}", text);
+    tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+            let state = app_handle.state::<AppState>();
+            if state.crdt_logging_enabled.load(Ordering::Relaxed) {
+                let text = {
+                    let document = state.document.lock().unwrap();
+                    document.debug_linked_list()
+                };
+                info!("CRDT linked list: {}", text);
+            }
         }
-        thread::sleep(Duration::from_secs(1));
     });
 }

--- a/tauri-app/src-tauri/src/gateway/gateway_api.rs
+++ b/tauri-app/src-tauri/src/gateway/gateway_api.rs
@@ -1,0 +1,70 @@
+use crate::gateway::types::{RoomResponse, GATEWAY_TIMEOUT};
+use log::{debug, warn};
+use url::Url;
+
+pub async fn create_room(port: u16) -> Result<String, String> {
+    debug!("fetching gateway room id via /rooms: port={port}");
+    tokio::time::timeout(GATEWAY_TIMEOUT, async {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/rooms"))
+            .send()
+            .await
+            .map_err(|e| format!("gateway /rooms: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("gateway /rooms: {e}"))?
+            .json::<RoomResponse>()
+            .await
+            .map(|r| r.room_id)
+            .map_err(|e| format!("gateway /rooms: {e}"))
+    })
+    .await
+    .map_err(|_| {
+        format!(
+            "gateway /rooms: timed out after {}s",
+            GATEWAY_TIMEOUT.as_secs()
+        )
+    })?
+}
+
+pub async fn destroy_room(local_room_url: String) -> Result<(), String> {
+    let end_session_url = end_session_url_from_room_url(&local_room_url)?;
+    tokio::time::timeout(GATEWAY_TIMEOUT, async {
+        reqwest::Client::new()
+            .post(&end_session_url)
+            .send()
+            .await
+            .map_err(|e| {
+                warn!("end-session HTTP request failed: {e}");
+                format!("Failed to notify gateway: {e}")
+            })?
+            .error_for_status()
+            .map_err(|e| {
+                warn!("end-session HTTP non-OK response: {e}");
+                format!("Gateway rejected end-session: {e}")
+            })?;
+        Ok::<(), String>(())
+    })
+    .await
+    .map_err(|_| {
+        format!(
+            "gateway /end-session: timed out after {}s",
+            GATEWAY_TIMEOUT.as_secs()
+        )
+    })??;
+    Ok(())
+}
+
+fn end_session_url_from_room_url(room_url: &str) -> Result<String, String> {
+    let parsed = Url::parse(room_url).map_err(|e| format!("invalid room URL: {e}"))?;
+    let room_id = parsed
+        .query_pairs()
+        .find(|(k, _)| k == "room")
+        .map(|(_, v)| v.into_owned())
+        .ok_or_else(|| "room URL is missing room query parameter".to_string())?;
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| "room URL is missing a valid port".to_string())?;
+    Ok(format!(
+        "http://127.0.0.1:{port}/end-session?room={room_id}"
+    ))
+}

--- a/tauri-app/src-tauri/src/gateway/mod.rs
+++ b/tauri-app/src-tauri/src/gateway/mod.rs
@@ -1,0 +1,2 @@
+pub mod gateway_api;
+mod types;

--- a/tauri-app/src-tauri/src/gateway/types.rs
+++ b/tauri-app/src-tauri/src/gateway/types.rs
@@ -1,0 +1,8 @@
+use std::time::Duration;
+
+pub const GATEWAY_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(serde::Deserialize)]
+pub struct RoomResponse {
+    pub(crate) room_id: String,
+}

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod app_config;
 mod crdt;
 mod debug;
+mod gateway;
 mod persistence;
 mod processes;
 mod session;
@@ -12,10 +13,11 @@ use crate::app_config::identity;
 use crate::crdt::local_op_handler;
 #[cfg(debug_assertions)]
 use crate::debug::document_logger::spawn_linked_list_logger;
-use crate::state::appstate::AppState;
+use crate::gateway::gateway_api::destroy_room;
+use crate::state::appstate::{AppRole, AppState};
 use crate::state::ws_state::WsState;
 use crdt_core::types::ClientId;
-use log::{debug, info};
+use log::{debug, info, warn};
 use rand::random;
 use tauri::Manager;
 use tauri_plugin_log::{Target, TargetKind};
@@ -69,7 +71,21 @@ pub fn run() {
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Destroyed = event {
                 info!("window destroyed; tearing down host resources");
-                window.state::<AppState>().teardown_host();
+                let state = window.state::<AppState>();
+                let local_room_url = {
+                    let role = state.role.lock().unwrap();
+                    match &*role {
+                        AppRole::Host { local_room_url, .. } => Some(local_room_url.clone()),
+                        _ => None,
+                    }
+                };
+                if let Some(url) = local_room_url {
+                    if let Err(e) = tauri::async_runtime::block_on(destroy_room(url)) {
+                        warn!("destroy_room on window close: {e}");
+                    }
+                }
+                state.leave_session(&window.state::<WsState>());
+                state.kill_host_processes();
             }
         })
         .plugin(tauri_plugin_opener::init())
@@ -84,12 +100,14 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             local_op_handler::insert,
             local_op_handler::delete,
-            session::command::start_host_session,
-            session::command::stop_host_session,
-            session::command::join_session,
-            session::command::disconnect_websocket,
-            session::command::parse_join_url,
-            session::command::get_session_info,
+            session::host_commands::host_session,
+            session::host_commands::end_session,
+            session::host_commands::kill_host_processes,
+            session::guest_commands::join_session,
+            session::guest_commands::parse_join_url,
+            session::joint_commands::get_session_info,
+            session::joint_commands::leave_session,
+            processes::commands::get_process_status,
             identity::get_identity,
             identity::set_username,
             persistence::commands::save_document,
@@ -100,6 +118,7 @@ pub fn run() {
             persistence::commands::get_document_text,
             persistence::commands::get_current_document_name,
             persistence::commands::save_text_file,
+            persistence::commands::reset_document,
             #[cfg(debug_assertions)]
             local_op_handler::toggle_crdt_logging
         ])

--- a/tauri-app/src-tauri/src/persistence/commands.rs
+++ b/tauri-app/src-tauri/src/persistence/commands.rs
@@ -3,6 +3,7 @@ use std::fs;
 use crate::persistence;
 use crate::state::appstate::AppState;
 use crdt_core::types::ClientId;
+use crdt_core::Document;
 use rand::random;
 use tauri::{AppHandle, State};
 
@@ -100,4 +101,12 @@ pub fn get_current_document_name(state: State<'_, AppState>) -> Result<Option<St
 #[tauri::command]
 pub fn save_text_file(path: String, content: String) -> Result<(), String> {
     fs::write(&path, &content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn reset_document(state: State<'_, AppState>) -> Result<(), String> {
+    let client_id = state.document.lock().unwrap().client_id;
+    state.replace_document(Document::new(client_id));
+    *state.current_document_name.lock().unwrap() = None;
+    Ok(())
 }

--- a/tauri-app/src-tauri/src/processes/commands.rs
+++ b/tauri-app/src-tauri/src/processes/commands.rs
@@ -1,0 +1,20 @@
+use crate::processes::types::{ProcessStatusResponse, SidecarStatus};
+use crate::state::appstate::AppState;
+use tauri::State;
+
+#[tauri::command]
+pub fn get_process_status(state: State<'_, AppState>) -> ProcessStatusResponse {
+    let procs = state.processes.lock().unwrap();
+    ProcessStatusResponse {
+        gateway: procs
+            .gateway
+            .as_ref()
+            .map(|s| s.status.clone())
+            .unwrap_or(SidecarStatus::Disabled),
+        tunnel: procs
+            .tunnel
+            .as_ref()
+            .map(|s| s.status.clone())
+            .unwrap_or(SidecarStatus::Disabled),
+    }
+}

--- a/tauri-app/src-tauri/src/processes/error.rs
+++ b/tauri-app/src-tauri/src/processes/error.rs
@@ -1,8 +1,11 @@
 use crate::session::session_types::{SessionErrorPayload, SESSION_ERROR};
 use crate::state::appstate::AppState;
+use crate::state::ws_state::WsState;
 use tauri::{AppHandle, Emitter, Manager};
 
 pub fn emit_error(app: &AppHandle, message: String) {
-    app.state::<AppState>().teardown_host();
+    let state = app.state::<AppState>();
+    state.leave_session(&app.state::<WsState>());
+    state.kill_host_processes();
     let _ = app.emit(SESSION_ERROR, SessionErrorPayload { message });
 }

--- a/tauri-app/src-tauri/src/processes/gateway_process.rs
+++ b/tauri-app/src-tauri/src/processes/gateway_process.rs
@@ -1,17 +1,10 @@
 use crate::app_config::config::AppConfig;
-use crate::processes::types::GatewayWorkflowResult;
+use crate::processes::types::{GatewayWorkflowResult, Sidecar, SidecarStatus};
 use crate::state::appstate::{AppRole, AppState};
 use log::{debug, info, warn};
-use std::time::Duration;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
-use tokio::sync::mpsc::Receiver;
-
-#[derive(serde::Deserialize)]
-struct RoomResponse {
-    room_id: String,
-}
 
 pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult>, String> {
     info!("gateway startup requested");
@@ -35,7 +28,11 @@ pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult
             return Ok(None);
         }
         drop(role);
-        state.processes.lock().unwrap().gateway = Some(child);
+        state.processes.lock().unwrap().gateway = Some(Sidecar {
+            proc: child,
+            name: "peercode-gateway".to_string(),
+            status: SidecarStatus::Enabled,
+        });
         debug!("gateway process handle stored in app state");
     }
 
@@ -45,11 +42,13 @@ pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult
             debug!("gateway stdout line received while waiting for port");
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(line.trim()) {
                 if let Some(port) = json.get("port").and_then(|v| v.as_u64()).map(|v| v as u16) {
-                    info!("gateway reported listening port={port}");
-                    let room_id = fetch_room_id(port).await?;
-                    let result = on_gateway_ready(app, port, &room_id, rx).await;
-                    info!("gateway ready on port={port}, room_id={room_id}");
-                    return Ok(result);
+                    info!("gateway ready on port={port}");
+
+                    return Ok(Some(GatewayWorkflowResult {
+                        lan_url: get_lan_url(port).await,
+                        port,
+                        log_rx: rx,
+                    }));
                 }
             }
         }
@@ -68,45 +67,12 @@ pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult
     }
 }
 
-async fn on_gateway_ready(
-    app: &AppHandle,
-    port: u16,
-    room_id: &str,
-    log_rx: Receiver<CommandEvent>,
-) -> Option<GatewayWorkflowResult> {
-    debug!("finalizing gateway readiness: port={port} room_id={room_id}");
-    let lan_url = get_lan_url(port, room_id).await;
-
-    {
-        let state = app.state::<AppState>();
-        let mut role = state.role.lock().unwrap();
-        if !matches!(*role, AppRole::Starting) {
-            warn!("gateway ready ignored: role changed before host transition");
-            return None;
-        }
-        *role = AppRole::Host {
-            room_id: room_id.to_string(),
-            lan_url: lan_url.clone(),
-            public_url: None,
-        };
-        info!("role transitioned to Host: room_id={room_id}");
-    }
-
-    Some(GatewayWorkflowResult {
-        lan_url,
-        port,
-        room_id: room_id.to_string(),
-        log_rx,
-    })
-}
-
-async fn get_lan_url(port: u16, room_id: &str) -> Option<String> {
-    debug!("resolving LAN websocket URL: port={port} room_id={room_id}");
-    let room_id = room_id.to_string();
+async fn get_lan_url(port: u16) -> Option<String> {
+    debug!("resolving LAN websocket URL: port={port}");
     let url = tauri::async_runtime::spawn_blocking(move || {
         local_ip_address::local_ip()
             .ok()
-            .map(|ip| format!("ws://{}:{}/ws?room={}", ip, port, room_id))
+            .map(|ip| format!("ws://{}:{}/ws", ip, port))
     })
     .await
     .ok()
@@ -117,32 +83,4 @@ async fn get_lan_url(port: u16, room_id: &str) -> Option<String> {
         warn!("LAN websocket URL resolution failed; LAN URL will be absent");
     }
     url
-}
-
-const FETCH_ROOM_TIMEOUT: Duration = Duration::from_secs(5);
-
-async fn fetch_room_id(port: u16) -> Result<String, String> {
-    debug!("fetching gateway room id via /rooms: port={port}");
-    tokio::time::timeout(FETCH_ROOM_TIMEOUT, fetch_room_id_inner(port))
-        .await
-        .map_err(|_| {
-            format!(
-                "gateway /rooms: timed out after {}s",
-                FETCH_ROOM_TIMEOUT.as_secs()
-            )
-        })?
-}
-
-async fn fetch_room_id_inner(port: u16) -> Result<String, String> {
-    reqwest::Client::new()
-        .post(format!("http://127.0.0.1:{port}/rooms"))
-        .send()
-        .await
-        .map_err(|e| format!("gateway /rooms: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("gateway /rooms: {e}"))?
-        .json::<RoomResponse>()
-        .await
-        .map(|r| r.room_id)
-        .map_err(|e| format!("gateway /rooms: {e}"))
 }

--- a/tauri-app/src-tauri/src/processes/mod.rs
+++ b/tauri-app/src-tauri/src/processes/mod.rs
@@ -2,5 +2,7 @@ mod error;
 mod gateway_process;
 mod tunnel_process;
 
+pub(crate) mod commands;
 pub mod process_coordinator;
-mod types;
+mod process_logger;
+pub(crate) mod types;

--- a/tauri-app/src-tauri/src/processes/process_coordinator.rs
+++ b/tauri-app/src-tauri/src/processes/process_coordinator.rs
@@ -1,13 +1,11 @@
 use crate::app_config::config::AppConfig;
 use crate::processes::error::emit_error;
 use crate::processes::gateway_process::run_gateway;
+use crate::processes::process_logger::pipe_process_logs;
 use crate::processes::tunnel_process::run_cloudflared;
 use crate::processes::types::CombinedWorkflowResult;
-use crate::session::session_types::{SessionReadyPayload, SESSION_READY};
 use log::{debug, error, info, warn};
-use tauri::{AppHandle, Emitter, Manager};
-use tauri_plugin_shell::process::CommandEvent;
-use tokio::sync::mpsc::Receiver;
+use tauri::{AppHandle, Manager};
 
 pub async fn launch(app: AppHandle) -> Result<CombinedWorkflowResult, String> {
     let logging = app.state::<AppConfig>().logging.clone();
@@ -20,8 +18,7 @@ pub async fn launch(app: AppHandle) -> Result<CombinedWorkflowResult, String> {
     let gateway = match run_gateway(&app).await {
         Ok(Some(r)) => {
             info!(
-                "gateway started: room_id={} port={} lan_url_present={}",
-                r.room_id,
+                "gateway started: port={} lan_url_present={}",
                 r.port,
                 r.lan_url.is_some()
             );
@@ -47,10 +44,9 @@ pub async fn launch(app: AppHandle) -> Result<CombinedWorkflowResult, String> {
 
     let lan_url = gateway.lan_url;
     let port = gateway.port;
-    let resolved_room_id = gateway.room_id.clone();
     let mut public_url: Option<String> = None;
 
-    match run_cloudflared(&app, port, &gateway.room_id).await {
+    match run_cloudflared(&app, port).await {
         Ok(Some(tunnel)) => {
             info!("cloudflared started: public_url={}", tunnel.public_url);
             if logging.show_cloudflared_logs {
@@ -71,50 +67,9 @@ pub async fn launch(app: AppHandle) -> Result<CombinedWorkflowResult, String> {
         }
     }
 
-    match app.emit(
-        SESSION_READY,
-        SessionReadyPayload {
-            lan_url,
-            public_url,
-            room_id: resolved_room_id.clone(),
-            port,
-        },
-    ) {
-        Ok(()) => info!(
-            "session ready event emitted: room_id={} port={}",
-            resolved_room_id, port
-        ),
-        Err(e) => warn!("failed to emit session ready event: {e}"),
-    }
-
-    info!(
-        "process coordinator launch completed: room_id={} port={}",
-        resolved_room_id, port
-    );
     Ok(CombinedWorkflowResult {
         port,
-        room_id: resolved_room_id,
+        lan_url,
+        public_url,
     })
-}
-
-async fn pipe_process_logs(name: &str, mut rx: Receiver<CommandEvent>) {
-    debug!("process log pipe started: name={name}");
-    while let Some(event) = rx.recv().await {
-        match event {
-            CommandEvent::Stdout(b) => {
-                info!("[{name}] {}", String::from_utf8_lossy(&b).trim_end());
-            }
-            CommandEvent::Stderr(b) => {
-                error!("[{name}] {}", String::from_utf8_lossy(&b).trim_end());
-            }
-            CommandEvent::Terminated(status) => {
-                info!("[{name}] terminated: {status:?}");
-                break;
-            }
-            _ => {
-                debug!("process log pipe ignored non-output event: name={name}");
-            }
-        }
-    }
-    debug!("process log pipe stopped: name={name}");
 }

--- a/tauri-app/src-tauri/src/processes/process_logger.rs
+++ b/tauri-app/src-tauri/src/processes/process_logger.rs
@@ -1,0 +1,25 @@
+use log::{debug, error, info};
+use tauri_plugin_shell::process::CommandEvent;
+use tokio::sync::mpsc::Receiver;
+
+pub async fn pipe_process_logs(name: &str, mut rx: Receiver<CommandEvent>) {
+    debug!("process log pipe started: name={name}");
+    while let Some(event) = rx.recv().await {
+        match event {
+            CommandEvent::Stdout(b) => {
+                info!("[{name}] {}", String::from_utf8_lossy(&b).trim_end());
+            }
+            CommandEvent::Stderr(b) => {
+                error!("[{name}] {}", String::from_utf8_lossy(&b).trim_end());
+            }
+            CommandEvent::Terminated(status) => {
+                info!("[{name}] terminated: {status:?}");
+                break;
+            }
+            _ => {
+                debug!("process log pipe ignored non-output event: name={name}");
+            }
+        }
+    }
+    debug!("process log pipe stopped: name={name}");
+}

--- a/tauri-app/src-tauri/src/processes/tunnel_process.rs
+++ b/tauri-app/src-tauri/src/processes/tunnel_process.rs
@@ -1,5 +1,5 @@
 use crate::app_config::config::AppConfig;
-use crate::processes::types::TunnelWorkflowResult;
+use crate::processes::types::{Sidecar, SidecarStatus, TunnelWorkflowResult};
 use crate::state::appstate::{AppRole, AppState};
 use log::{debug, info, warn};
 use tauri::{AppHandle, Manager};
@@ -9,9 +9,8 @@ use tauri_plugin_shell::ShellExt;
 pub async fn run_cloudflared(
     app: &AppHandle,
     port: u16,
-    room_id: &str,
 ) -> Result<Option<TunnelWorkflowResult>, String> {
-    info!("cloudflared startup requested: port={port} room_id={room_id}");
+    info!("cloudflared startup requested: port={port}");
     let url_arg = format!("http://localhost:{port}");
     let tunnel_log_level = app.state::<AppConfig>().logging.tunnel_level_for_arg();
     debug!("cloudflared startup using log level: {}", tunnel_log_level);
@@ -32,7 +31,11 @@ pub async fn run_cloudflared(
         .spawn()
         .map_err(|e| format!("Failed to spawn cloudflared: {e}"))?;
 
-    app.state::<AppState>().processes.lock().unwrap().tunnel = Some(child);
+    app.state::<AppState>().processes.lock().unwrap().tunnel = Some(Sidecar {
+        proc: child,
+        name: "cloudflared".to_string(),
+        status: SidecarStatus::Enabled,
+    });
     debug!("cloudflared process handle stored in app state");
 
     while let Some(event) = rx.recv().await {
@@ -45,7 +48,7 @@ pub async fn run_cloudflared(
                 } else {
                     raw_url.replacen("http://", "ws://", 1)
                 };
-                let public_url = format!("{}/ws?room={}", ws_url, room_id);
+                let public_url = format!("{}/ws", ws_url);
                 info!("cloudflared tunnel URL discovered");
                 store_public_url(app, &public_url);
 

--- a/tauri-app/src-tauri/src/processes/types.rs
+++ b/tauri-app/src-tauri/src/processes/types.rs
@@ -1,10 +1,21 @@
-use tauri_plugin_shell::process::CommandEvent;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tokio::sync::mpsc::Receiver;
+
+#[derive(serde::Serialize, Clone, PartialEq)]
+pub enum SidecarStatus {
+    Enabled,
+    Disabled,
+}
+
+pub struct Sidecar {
+    pub proc: CommandChild,
+    pub name: String,
+    pub status: SidecarStatus,
+}
 
 pub struct GatewayWorkflowResult {
     pub lan_url: Option<String>,
     pub port: u16,
-    pub room_id: String,
     pub log_rx: Receiver<CommandEvent>,
 }
 
@@ -15,5 +26,12 @@ pub struct TunnelWorkflowResult {
 
 pub struct CombinedWorkflowResult {
     pub port: u16,
-    pub room_id: String,
+    pub public_url: Option<String>,
+    pub lan_url: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct ProcessStatusResponse {
+    pub gateway: SidecarStatus,
+    pub tunnel: SidecarStatus,
 }

--- a/tauri-app/src-tauri/src/session/command_tests.rs
+++ b/tauri-app/src-tauri/src/session/command_tests.rs
@@ -1,4 +1,4 @@
-use super::command::parse_join_url;
+use crate::session::guest_commands::parse_join_url;
 
 #[test]
 fn parses_default_ws_endpoint() {

--- a/tauri-app/src-tauri/src/session/guest_commands.rs
+++ b/tauri-app/src-tauri/src/session/guest_commands.rs
@@ -1,36 +1,9 @@
-use crate::processes::process_coordinator;
-use crate::session::session_types::{JoinInfo, SessionInfo};
+use crate::session::session_types::JoinInfo;
 use crate::state::appstate::{AppRole, AppState};
 use crate::state::ws_state::WsState;
-use log::{debug, error, info, warn};
-use tauri::{AppHandle, Manager, State};
+use log::{debug, info, warn};
+use tauri::{AppHandle, State};
 use url::Url;
-
-#[tauri::command]
-pub async fn start_host_session(app: AppHandle) -> Result<(), String> {
-    debug!("start_host_session requested");
-    {
-        let state = app.state::<AppState>();
-        let mut role = state.role.lock().unwrap();
-        if !role.can_initiate_session() {
-            warn!("start_host_session rejected: active session already exists");
-            return Err("A session is already active".into());
-        }
-        *role = AppRole::Starting;
-        debug!("start_host_session role set to Starting");
-    }
-
-    info!("start_host_session launching gateway/tunnel workflow");
-    let result = process_coordinator::launch(app.clone()).await?;
-    info!(
-        "start_host_session workflow ready: room_id={} port={}",
-        result.room_id, result.port
-    );
-
-    connect(app, result.port, result.room_id).await;
-    info!("start_host_session completed");
-    Ok(())
-}
 
 #[tauri::command]
 pub async fn join_session(
@@ -110,51 +83,6 @@ pub async fn join_session(
 }
 
 #[tauri::command]
-pub fn stop_host_session(state: State<'_, AppState>) -> Result<(), String> {
-    info!("stop_host_session requested");
-    state.teardown_host();
-    info!("stop_host_session completed");
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn disconnect_websocket(ws: State<'_, WsState>) -> Result<(), String> {
-    debug!("disconnect_websocket requested");
-    ws.disconnect().await.map_err(|e| {
-        warn!("disconnect_websocket failed: {e}");
-        e.to_string()
-    })?;
-    info!("disconnect_websocket completed");
-    Ok(())
-}
-
-#[tauri::command]
-pub fn get_session_info(state: State<'_, AppState>) -> SessionInfo {
-    let role = state.role.lock().unwrap();
-    let (lan_url, public_url, room_id) = match &*role {
-        AppRole::Host {
-            room_id,
-            lan_url,
-            public_url,
-            ..
-        } => (lan_url.clone(), public_url.clone(), Some(room_id.clone())),
-        AppRole::Guest {
-            room_id,
-            server_url,
-        } => (None, Some(server_url.clone()), Some(room_id.clone())),
-        _ => (None, None, None),
-    };
-    let info = SessionInfo {
-        status: role.status().into(),
-        lan_url,
-        public_url,
-        room_id,
-    };
-    debug!("get_session_info returned status={}", info.status);
-    info
-}
-
-#[tauri::command]
 pub fn parse_join_url(url: String) -> Result<JoinInfo, String> {
     debug!("parse_join_url requested");
     let parsed = Url::parse(&url).map_err(|e| format!("Invalid URL: {e}"))?;
@@ -210,31 +138,4 @@ pub fn parse_join_url(url: String) -> Result<JoinInfo, String> {
         info.server_url, info.room_id
     );
     Ok(info)
-}
-
-async fn connect(app: AppHandle, port: u16, room_id: String) {
-    debug!(
-        "host local connect requested: room_id={} port={}",
-        room_id, port
-    );
-    let host_client_id = {
-        let state = app.state::<AppState>();
-        let doc = state.document.lock().unwrap();
-        doc.client_id.value
-    };
-
-    let local_ws_url =
-        format!("ws://127.0.0.1:{port}/ws?room={room_id}&client_id={host_client_id}");
-    let ws = app.state::<WsState>();
-    if let Err(e) = ws
-        .connect(&local_ws_url, room_id.clone(), app.clone())
-        .await
-    {
-        error!("local websocket connection failed (session still running): {e}");
-    } else {
-        info!(
-            "local websocket connection established for host session: room_id={}",
-            room_id
-        );
-    }
 }

--- a/tauri-app/src-tauri/src/session/host_commands.rs
+++ b/tauri-app/src-tauri/src/session/host_commands.rs
@@ -1,0 +1,184 @@
+use crate::gateway::gateway_api::{create_room, destroy_room};
+use crate::processes::process_coordinator;
+use crate::processes::types::SidecarStatus;
+use crate::session::session_types::{SessionReadyPayload, SESSION_READY};
+use crate::state::appstate::{AppRole, AppState};
+use crate::state::ws_state::WsState;
+use log::{debug, error, info, warn};
+use tauri::{AppHandle, Emitter, Manager, State};
+
+struct HostSessionSetup {
+    room_id: String,
+    port: u16,
+    lan_url: Option<String>,
+    public_url: Option<String>,
+    local_room_url: String,
+    public_room_url: Option<String>,
+}
+
+#[tauri::command]
+pub async fn host_session(app: AppHandle) -> Result<(), String> {
+    debug!("start_host_session requested");
+
+    {
+        let state = app.state::<AppState>();
+        let mut role = state.role.lock().unwrap();
+        if !matches!(*role, AppRole::Undecided) {
+            warn!(
+                "start_host_session rejected: expected idle role, got {}",
+                role.status()
+            );
+            return Err("A session is already active".into());
+        }
+        *role = AppRole::Starting;
+        debug!("start_host_session role set to Starting");
+    }
+
+    ensure_gateway_spawn_allowed(&app)?;
+
+    let setup = match prepare_host_session(&app).await {
+        Ok(result) => result,
+        Err(e) => {
+            rollback_starting_role(&app);
+            return Err(e);
+        }
+    };
+
+    transition_to_host(&app, &setup);
+    emit_session_ready(&app, &setup)?;
+    info!(
+        "start_host_session workflow ready: room_id={} port={}",
+        setup.room_id, setup.port
+    );
+
+    connect(app, setup.port, setup.room_id).await;
+    info!("start_host_session completed");
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn end_session(state: State<'_, AppState>, ws: State<'_, WsState>) -> Result<(), String> {
+    info!("end_session requested");
+    let (room_id, local_room_url) = {
+        let role = state.role.lock().unwrap();
+        match &*role {
+            AppRole::Host {
+                room_id,
+                local_room_url,
+                ..
+            } => (room_id.clone(), local_room_url.clone()),
+            _ => {
+                warn!("end_session rejected: not a host");
+                return Err("Not currently hosting a session".into());
+            }
+        }
+    };
+    state.leave_session(&ws);
+    destroy_room(local_room_url).await?;
+    info!("end_session completed: room_id={room_id}");
+    Ok(())
+}
+
+#[tauri::command]
+pub fn kill_host_processes(state: State<'_, AppState>) -> Result<(), String> {
+    info!("kill_host_processes requested");
+    state.kill_host_processes();
+    info!("kill_host_processes completed");
+    Ok(())
+}
+
+fn ensure_gateway_spawn_allowed(app: &AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let procs = state.processes.lock().unwrap();
+    let should_launch_processes = procs
+        .gateway
+        .as_ref()
+        .map(|s| s.status == SidecarStatus::Disabled)
+        .unwrap_or(true);
+    if !should_launch_processes {
+        rollback_starting_role(app);
+        return Err("Gateway sidecar is already running; refusing to launch a duplicate".into());
+    }
+    Ok(())
+}
+
+async fn prepare_host_session(app: &AppHandle) -> Result<HostSessionSetup, String> {
+    info!("start_host_session launching gateway/tunnel workflow");
+    let workflow = process_coordinator::launch(app.clone()).await?;
+    let room_id = create_room(workflow.port).await?;
+    let local_room_url = format!("ws://127.0.0.1:{}/ws?room={}", workflow.port, room_id);
+    let public_url = workflow.public_url;
+    let public_room_url = public_url
+        .as_ref()
+        .map(|url| format!("{url}?room={room_id}"));
+
+    Ok(HostSessionSetup {
+        room_id: room_id.clone(),
+        port: workflow.port,
+        lan_url: workflow.lan_url,
+        public_url,
+        local_room_url,
+        public_room_url,
+    })
+}
+
+fn transition_to_host(app: &AppHandle, setup: &HostSessionSetup) {
+    let state = app.state::<AppState>();
+    let mut role = state.role.lock().unwrap();
+    *role = AppRole::Host {
+        room_id: setup.room_id.clone(),
+        lan_url: setup.lan_url.clone(),
+        public_url: setup.public_url.clone(),
+        local_room_url: setup.local_room_url.clone(),
+        public_room_url: setup.public_room_url.clone(),
+    };
+}
+
+fn emit_session_ready(app: &AppHandle, setup: &HostSessionSetup) -> Result<(), String> {
+    let payload = SessionReadyPayload {
+        lan_url: setup.lan_url.clone(),
+        public_url: setup.public_url.clone(),
+        local_room_url: setup.local_room_url.clone(),
+        public_room_url: setup.public_room_url.clone(),
+        room_id: setup.room_id.clone(),
+        port: setup.port,
+    };
+    app.emit(SESSION_READY, payload)
+        .map_err(|e| format!("failed to emit session ready event: {e}"))
+}
+
+fn rollback_starting_role(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    let mut role = state.role.lock().unwrap();
+    if matches!(*role, AppRole::Starting) {
+        *role = AppRole::Undecided;
+        warn!("start_host_session failed; role rolled back to idle");
+    }
+}
+
+async fn connect(app: AppHandle, port: u16, room_id: String) {
+    debug!(
+        "host local connect requested: room_id={} port={}",
+        room_id, port
+    );
+    let host_client_id = {
+        let state = app.state::<AppState>();
+        let doc = state.document.lock().unwrap();
+        doc.client_id.value
+    };
+
+    let local_ws_url =
+        format!("ws://127.0.0.1:{port}/ws?room={room_id}&client_id={host_client_id}");
+    let ws = app.state::<WsState>();
+    if let Err(e) = ws
+        .connect(&local_ws_url, room_id.clone(), app.clone())
+        .await
+    {
+        error!("local websocket connection failed (session still running): {e}");
+    } else {
+        info!(
+            "local websocket connection established for host session: room_id={}",
+            room_id
+        );
+    }
+}

--- a/tauri-app/src-tauri/src/session/joint_commands.rs
+++ b/tauri-app/src-tauri/src/session/joint_commands.rs
@@ -1,0 +1,55 @@
+use crate::session::session_types::SessionInfo;
+use crate::state::appstate::{AppRole, AppState};
+use crate::state::ws_state::WsState;
+use log::{debug, info};
+use tauri::State;
+
+#[tauri::command]
+pub fn get_session_info(state: State<'_, AppState>) -> SessionInfo {
+    let role = state.role.lock().unwrap();
+    let (lan_url, public_url, local_room_url, public_room_url, room_id) = match &*role {
+        AppRole::Host {
+            room_id,
+            lan_url,
+            public_url,
+            local_room_url,
+            public_room_url,
+            ..
+        } => (
+            lan_url.clone(),
+            public_url.clone(),
+            Some(local_room_url.clone()),
+            public_room_url.clone(),
+            Some(room_id.clone()),
+        ),
+        AppRole::Guest {
+            room_id,
+            server_url,
+        } => (
+            None,
+            Some(server_url.clone()),
+            None,
+            None,
+            Some(room_id.clone()),
+        ),
+        _ => (None, None, None, None, None),
+    };
+    let info = SessionInfo {
+        status: role.status().into(),
+        lan_url,
+        public_url,
+        local_room_url,
+        public_room_url,
+        room_id,
+    };
+    debug!("get_session_info returned status={}", info.status);
+    info
+}
+
+#[tauri::command]
+pub fn leave_session(state: State<'_, AppState>, ws: State<'_, WsState>) -> Result<(), String> {
+    info!("leave session requested");
+    state.leave_session(&ws);
+    info!("leave session completed");
+    Ok(())
+}

--- a/tauri-app/src-tauri/src/session/mod.rs
+++ b/tauri-app/src-tauri/src/session/mod.rs
@@ -1,4 +1,6 @@
-pub mod command;
 #[cfg(test)]
 mod command_tests;
+pub(crate) mod guest_commands;
+pub mod host_commands;
+pub(crate) mod joint_commands;
 pub mod session_types;

--- a/tauri-app/src-tauri/src/session/session_types.rs
+++ b/tauri-app/src-tauri/src/session/session_types.rs
@@ -1,10 +1,16 @@
 pub const SESSION_READY: &str = "session://session-ready";
 pub const SESSION_ERROR: &str = "session://session-error";
+pub const SESSION_ENDED: &str = "session://session-ended";
+
+#[derive(Clone, serde::Serialize)]
+pub struct SessionEndedPayload {}
 
 #[derive(Clone, serde::Serialize)]
 pub struct SessionReadyPayload {
     pub lan_url: Option<String>,
     pub public_url: Option<String>,
+    pub local_room_url: String,
+    pub public_room_url: Option<String>,
     pub room_id: String,
     pub port: u16,
 }
@@ -19,6 +25,8 @@ pub struct SessionInfo {
     pub status: String,
     pub lan_url: Option<String>,
     pub public_url: Option<String>,
+    pub local_room_url: Option<String>,
+    pub public_room_url: Option<String>,
     pub room_id: Option<String>,
 }
 

--- a/tauri-app/src-tauri/src/state/appstate.rs
+++ b/tauri-app/src-tauri/src/state/appstate.rs
@@ -1,10 +1,10 @@
+use crate::processes::types::Sidecar;
+use crate::state::ws_state::WsState;
 use crdt_core::types::ClientId;
 use crdt_core::Document;
 use log::{info, warn};
 use std::sync::atomic::AtomicBool;
 use std::sync::Mutex;
-use tauri_plugin_shell::process::CommandChild;
-
 pub struct AppState {
     pub document: Mutex<Document>,
     pub role: Mutex<AppRole>,
@@ -14,6 +14,7 @@ pub struct AppState {
     pub crdt_logging_enabled: AtomicBool,
 }
 
+#[derive(Clone)]
 pub enum AppRole {
     Undecided,
     Starting,
@@ -21,6 +22,8 @@ pub enum AppRole {
         room_id: String,
         lan_url: Option<String>,
         public_url: Option<String>,
+        local_room_url: String,
+        public_room_url: Option<String>,
     },
     Guest {
         room_id: String,
@@ -39,13 +42,13 @@ impl AppRole {
     }
 
     pub fn can_initiate_session(&self) -> bool {
-        matches!(self, Self::Undecided | Self::Starting)
+        matches!(self, Self::Undecided)
     }
 }
 
 pub struct HostProcesses {
-    pub gateway: Option<CommandChild>,
-    pub tunnel: Option<CommandChild>,
+    pub gateway: Option<Sidecar>,
+    pub tunnel: Option<Sidecar>,
 }
 
 impl AppState {
@@ -68,33 +71,31 @@ impl AppState {
         *current = doc;
     }
 
-    pub fn teardown_host(&self) {
-        info!("teardown_host requested");
-        let mut role = self.role.lock().unwrap();
-        let previous_status = role.status();
-        if matches!(*role, AppRole::Starting | AppRole::Host { .. }) {
+    pub fn leave_session(&self, ws: &WsState) {
+        let previous_role = {
+            let mut role = self.role.lock().unwrap();
+            let prev = role.clone();
             *role = AppRole::Undecided;
-            info!(
-                "teardown_host role reset to idle from status={}",
-                previous_status
-            );
-        }
+            prev
+        };
+        info!("role reset to idle from status={}", previous_role.status());
 
+        ws.disconnect_nowait();
+    }
+
+    pub fn kill_host_processes(&self) {
         let mut procs = self.processes.lock().unwrap();
-        if let Some(child) = procs.tunnel.take() {
-            if let Err(e) = child.kill() {
-                warn!("teardown_host failed to kill tunnel process: {}", e);
+        self.kill_proc(procs.tunnel.take());
+        self.kill_proc(procs.gateway.take());
+    }
+
+    fn kill_proc(&self, proc: Option<Sidecar>) {
+        if let Some(sidecar) = proc {
+            if let Err(e) = sidecar.proc.kill() {
+                warn!("failed to kill sidecar '{}': {}", sidecar.name, e);
             } else {
-                info!("teardown_host killed tunnel process");
+                info!("killed sidecar '{}'", sidecar.name);
             }
         }
-        if let Some(child) = procs.gateway.take() {
-            if let Err(e) = child.kill() {
-                warn!("teardown_host failed to kill gateway process: {}", e);
-            } else {
-                info!("teardown_host killed gateway process");
-            }
-        }
-        info!("teardown_host completed");
     }
 }

--- a/tauri-app/src-tauri/src/state/ws_state.rs
+++ b/tauri-app/src-tauri/src/state/ws_state.rs
@@ -88,6 +88,7 @@ impl WsState {
             Arc::clone(&self.connection),
             Arc::clone(&self.write_tx),
             op_tx,
+            app.clone(),
         ));
         debug!("ws sender/receiver/processor tasks spawned");
 
@@ -128,29 +129,46 @@ impl WsState {
         }
     }
 
+    fn do_disconnect(
+        guard: &mut WsConnection,
+        write_tx: &RwLock<Option<Arc<mpsc::Sender<Message>>>>,
+    ) -> bool {
+        if let WsConnection::Connected {
+            receiver,
+            sender,
+            processor,
+            ..
+        } = guard
+        {
+            receiver.abort();
+            sender.abort();
+            processor.abort();
+            *write_tx.write().unwrap() = None;
+            *guard = WsConnection::Disconnected;
+            info!("websocket disconnected");
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn disconnect_nowait(&self) {
+        let connection = Arc::clone(&self.connection);
+        let write_tx = Arc::clone(&self.write_tx);
+        tauri::async_runtime::spawn(async move {
+            let mut guard = connection.lock().await;
+            Self::do_disconnect(&mut guard, &write_tx);
+        });
+    }
+
     pub async fn disconnect(&self) -> Result<(), WsError> {
         debug!("ws disconnect request received");
         let mut guard = self.connection.lock().await;
-        match &mut *guard {
-            WsConnection::Connected {
-                receiver,
-                sender,
-                processor,
-                ..
-            } => {
-                debug!("ws disconnect: aborting sender/receiver/processor tasks");
-                receiver.abort();
-                sender.abort();
-                processor.abort();
-                *self.write_tx.write().unwrap() = None;
-                *guard = WsConnection::Disconnected;
-                info!("websocket disconnected");
-                Ok(())
-            }
-            _ => {
-                warn!("ws disconnect rejected: no active connection");
-                Err(WsError::NotConnected)
-            }
+        if Self::do_disconnect(&mut guard, &self.write_tx) {
+            Ok(())
+        } else {
+            warn!("ws disconnect rejected: no active connection");
+            Err(WsError::NotConnected)
         }
     }
 }

--- a/tauri-app/src-tauri/src/ws_management/ws_receiver.rs
+++ b/tauri-app/src-tauri/src/ws_management/ws_receiver.rs
@@ -1,10 +1,12 @@
-use std::sync::{Arc, RwLock};
-
+use crdt_core::wire::{CONTROL_SESSION_ENDED, PREFIX_CONTROL};
 use futures_util::StreamExt;
 use log::{debug, info, warn};
+use std::sync::{Arc, RwLock};
+use tauri::{AppHandle, Emitter};
 use tokio::sync::{mpsc, Mutex};
 use tokio_tungstenite::tungstenite::Message;
 
+use crate::session::session_types::{SessionEndedPayload, SESSION_ENDED};
 use crate::ws_management::ws_types::{Stream, WsConnection};
 
 pub async fn receive_loop(
@@ -12,6 +14,7 @@ pub async fn receive_loop(
     connection: Arc<Mutex<WsConnection>>,
     write_tx: Arc<RwLock<Option<Arc<mpsc::Sender<Message>>>>>,
     op_tx: mpsc::UnboundedSender<Vec<u8>>,
+    app: AppHandle,
 ) {
     info!("ws receiver loop started");
     while let Some(result) = stream.next().await {
@@ -20,6 +23,18 @@ pub async fn receive_loop(
                 debug!("ws recv text (len={}): {text}", text.len());
             }
             Ok(Message::Binary(bytes)) => {
+                if bytes.first().copied() == Some(PREFIX_CONTROL) {
+                    match bytes.get(1).copied() {
+                        Some(CONTROL_SESSION_ENDED) => {
+                            info!("ws recv: session ended by host");
+                            let _ = app.emit(SESSION_ENDED, SessionEndedPayload {});
+                            break;
+                        }
+                        other => {
+                            warn!("ws recv: unknown control frame type={:?}; ignoring", other);
+                        }
+                    }
+                }
                 debug!("ws receiver binary message (bytes={})", bytes.len());
                 if op_tx.send(bytes.into()).is_err() {
                     warn!("ws receiver: op processor channel closed; dropping frame");

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -1,10 +1,23 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type FormEvent,
+} from "react";
 import type { editor } from "monaco-editor";
 import Editor, { type OnMount, type Monaco } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useRemoteChangeListener } from "./remoteChangeListener";
-import { UsernameGate } from "./usernameSetup";
+import {
+  UsernameGate,
+  overlayStyle,
+  cardStyle,
+  inputStyle,
+  btnStyle,
+  errorStyle,
+} from "./usernameSetup";
 import { FileMenu } from "./FileMenu";
 import "./App.css";
 
@@ -14,6 +27,156 @@ interface LogEntry {
   operationLabel: string;
   payload: string;
   wireMessage?: string;
+}
+
+// --- Save-before-session modal ---
+interface SavePromptProps {
+  onSaveAndContinue: (name: string) => Promise<void>;
+  onDiscardAndContinue: () => void;
+  onCancel: () => void;
+}
+
+function SaveBeforeSessionModal({
+  onSaveAndContinue,
+  onDiscardAndContinue,
+  onCancel,
+}: SavePromptProps) {
+  const [name, setName] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    invoke<string | null>("get_current_document_name").then((n) => {
+      if (n) setName(n);
+    });
+  }, []);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError("Enter a document name");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      await onSaveAndContinue(name.trim());
+    } catch (err) {
+      setError(String(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={overlayStyle}>
+      <div style={cardStyle}>
+        <div style={{ fontSize: 16, fontWeight: "bold", color: "#eee" }}>
+          Unsaved changes
+        </div>
+        <div style={{ fontSize: 13, color: "#aaa" }}>
+          Your document has content. Save it before starting a new session?
+        </div>
+        <input
+          style={inputStyle}
+          autoFocus
+          placeholder="Document name"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            setError("");
+          }}
+        />
+        <div style={errorStyle}>{error}</div>
+        <button
+          style={btnStyle(busy || !name.trim())}
+          disabled={busy || !name.trim()}
+          onClick={() => void handleSave()}
+        >
+          {busy ? "saving…" : "Save & Continue"}
+        </button>
+        <button
+          style={{ ...btnStyle(busy), background: busy ? "#333" : "#7a3a2a" }}
+          disabled={busy}
+          onClick={onDiscardAndContinue}
+        >
+          Discard & Continue
+        </button>
+        <button
+          style={{ ...btnStyle(false), background: "#444" }}
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// --- Join URL modal ---
+interface JoinModalProps {
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+function JoinModal({ onSuccess, onCancel }: JoinModalProps) {
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError("");
+    try {
+      await invoke("join_session", { url: trimmed });
+      onSuccess();
+    } catch (err) {
+      setError(String(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={overlayStyle}>
+      <form style={cardStyle} onSubmit={(e) => void handleSubmit(e)}>
+        <div style={{ fontSize: 16, fontWeight: "bold", color: "#eee" }}>
+          Join a session
+        </div>
+        <div style={{ fontSize: 13, color: "#aaa" }}>
+          Paste the session URL shared by the host.
+        </div>
+        <input
+          style={inputStyle}
+          autoFocus
+          placeholder="wss://example.com/ws?room=…"
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            setError("");
+          }}
+        />
+        <div style={errorStyle}>{error}</div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            style={{ ...btnStyle(busy), background: busy ? "#333" : "#444" }}
+            disabled={busy}
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            style={btnStyle(busy || !url.trim())}
+            disabled={busy || !url.trim()}
+          >
+            {busy ? "connecting…" : "Connect"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
 }
 
 interface AppContentProps {
@@ -65,8 +228,100 @@ function AppContent({ username }: AppContentProps) {
   // --- session links ---
   const [lanUrl, setLanUrl] = useState<string | null>(null);
   const [publicUrl, setPublicUrl] = useState<string | null>(null);
-  const [sessionStatus, setSessionStatus] = useState<string>("starting...");
+  const [sessionStatus, setSessionStatus] = useState<string>("loading");
+  const sessionStatusRef = useRef(sessionStatus);
+  sessionStatusRef.current = sessionStatus;
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const [sessionEndedBanner, setSessionEndedBanner] = useState(false);
+  const [processesRunning, setProcessesRunning] = useState({
+    gateway: "Disabled" as "Enabled" | "Disabled",
+    tunnel: "Disabled" as "Enabled" | "Disabled",
+  });
+
+  // --- idle session actions ---
+  const [sessionBusy, setSessionBusy] = useState(false);
+  const [showJoinModal, setShowJoinModal] = useState(false);
+  const [showSavePrompt, setShowSavePrompt] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"host" | "join" | null>(
+    null,
+  );
+
+  const resetDocAndEditor = useCallback(async () => {
+    await invoke("reset_document");
+    isApplyingRemote.current = true;
+    editorRef.current?.setValue("");
+    isApplyingRemote.current = false;
+  }, []);
+
+  const performAction = useCallback(
+    async (action: "host" | "join") => {
+      await resetDocAndEditor();
+      if (action === "host") {
+        setSessionBusy(true);
+        try {
+          await invoke("host_session");
+        } catch (err) {
+          setSessionStatus("error: " + String(err));
+        } finally {
+          setSessionBusy(false);
+        }
+      } else {
+        setShowJoinModal(true);
+      }
+    },
+    [resetDocAndEditor],
+  );
+
+  const handleHostClick = useCallback(async () => {
+    const content = editorRef.current?.getValue() ?? "";
+    if (content.length > 0) {
+      setPendingAction("host");
+      setShowSavePrompt(true);
+    } else {
+      await performAction("host");
+    }
+  }, [performAction]);
+
+  const handleJoinClick = useCallback(async () => {
+    const content = editorRef.current?.getValue() ?? "";
+    if (content.length > 0) {
+      setPendingAction("join");
+      setShowSavePrompt(true);
+    } else {
+      await performAction("join");
+    }
+  }, [performAction]);
+
+  const handleSaveAndContinue = useCallback(
+    async (name: string) => {
+      await invoke("save_document", { name });
+      setShowSavePrompt(false);
+      const action = pendingAction!;
+      setPendingAction(null);
+      await performAction(action);
+    },
+    [pendingAction, performAction],
+  );
+
+  const handleDiscardAndContinue = useCallback(async () => {
+    setShowSavePrompt(false);
+    const action = pendingAction!;
+    setPendingAction(null);
+    await performAction(action);
+  }, [pendingAction, performAction]);
+
+  const handleJoinSuccess = useCallback(async () => {
+    setShowJoinModal(false);
+    const info = await invoke<{
+      status: string;
+      public_url: string | null;
+      public_room_url: string | null;
+    }>("get_session_info");
+    setSessionStatus(info.status);
+    if (info.public_room_url ?? info.public_url) {
+      setPublicUrl(info.public_room_url ?? info.public_url);
+    }
+  }, []);
 
   const copyUrl = async (label: string, url: string) => {
     try {
@@ -84,11 +339,21 @@ function AppContent({ username }: AppContentProps) {
       status: string;
       lan_url: string | null;
       public_url: string | null;
+      local_room_url: string | null;
+      public_room_url: string | null;
     }>("get_session_info").then((info) => {
       setSessionStatus(info.status);
-      if (info.lan_url) setLanUrl(info.lan_url);
-      if (info.public_url) setPublicUrl(info.public_url);
+      if (info.local_room_url ?? info.lan_url) {
+        setLanUrl(info.local_room_url ?? info.lan_url);
+      }
+      if (info.public_room_url ?? info.public_url) {
+        setPublicUrl(info.public_room_url ?? info.public_url);
+      }
     });
+
+    invoke<{ gateway: "Enabled" | "Disabled"; tunnel: "Enabled" | "Disabled" }>(
+      "get_process_status",
+    ).then((s) => setProcessesRunning(s));
 
     const unlisten: (() => void)[] = [];
     (async () => {
@@ -96,17 +361,36 @@ function AppContent({ username }: AppContentProps) {
         await listen<{
           lan_url: string | null;
           public_url: string | null;
+          local_room_url: string;
+          public_room_url: string | null;
           port: number;
           room_id: string;
         }>("session://session-ready", (e) => {
           setSessionStatus("host");
-          if (e.payload.lan_url) setLanUrl(e.payload.lan_url);
-          if (e.payload.public_url) setPublicUrl(e.payload.public_url);
+          setLanUrl(e.payload.local_room_url);
+          setPublicUrl(e.payload.public_room_url);
+          setProcessesRunning({
+            gateway: "Enabled",
+            tunnel: e.payload.public_url !== null ? "Enabled" : "Disabled",
+          });
         }),
       );
       unlisten.push(
         await listen<{ message: string }>("session://session-error", (e) => {
           setSessionStatus("error: " + e.payload.message);
+          setProcessesRunning({ gateway: "Disabled", tunnel: "Disabled" });
+        }),
+      );
+      unlisten.push(
+        await listen("session://session-ended", () => {
+          // Guests only: the gateway may echo end-session to the host too.
+          if (sessionStatusRef.current !== "guest") return;
+          void invoke("leave_session").then(() => {
+            setSessionStatus("idle");
+            setPublicUrl(null);
+            setSessionEndedBanner(true);
+            window.setTimeout(() => setSessionEndedBanner(false), 5000);
+          });
         }),
       );
     })();
@@ -254,12 +538,88 @@ function AppContent({ username }: AppContentProps) {
           fontSize: "12px",
         }}
       >
-        <span style={{ color: "#aaa" }}>Session: </span>
-        <span
-          style={{ color: sessionStatus.startsWith("error") ? "#f55" : "#0f0" }}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            flexWrap: "wrap",
+          }}
         >
-          {sessionStatus}
-        </span>
+          <span>
+            <span style={{ color: "#aaa" }}>Session: </span>
+            <span
+              style={{
+                color: sessionStatus.startsWith("error") ? "#f55" : "#0f0",
+              }}
+            >
+              {sessionStatus}
+            </span>
+          </span>
+          {(processesRunning.gateway === "Enabled" ||
+            processesRunning.tunnel === "Enabled") && (
+            <span style={{ display: "flex", gap: 6 }}>
+              {processesRunning.gateway === "Enabled" && (
+                <span
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 5,
+                    padding: "2px 8px",
+                    borderRadius: 12,
+                    background: "#0d2a1a",
+                    border: "1px solid #2ecc71",
+                    color: "#2ecc71",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: "0.04em",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: "#2ecc71",
+                      boxShadow: "0 0 5px #2ecc71",
+                      display: "inline-block",
+                    }}
+                  />
+                  gateway
+                </span>
+              )}
+              {processesRunning.tunnel === "Enabled" && (
+                <span
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 5,
+                    padding: "2px 8px",
+                    borderRadius: 12,
+                    background: "#0d1e2a",
+                    border: "1px solid #3498db",
+                    color: "#3498db",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: "0.04em",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: "#3498db",
+                      boxShadow: "0 0 5px #3498db",
+                      display: "inline-block",
+                    }}
+                  />
+                  tunnel
+                </span>
+              )}
+            </span>
+          )}
+        </div>
         {lanUrl && (
           <div
             style={{
@@ -310,10 +670,158 @@ function AppContent({ username }: AppContentProps) {
         {copyStatus && (
           <div style={{ color: "#9ad", marginTop: 4 }}>{copyStatus}</div>
         )}
-        {!lanUrl && !publicUrl && sessionStatus === "starting..." && (
+        {sessionStatus === "starting" && (
           <span style={{ color: "#888", marginLeft: 8 }}>
-            waiting for session readiness...
+            starting session...
           </span>
+        )}
+        {sessionStatus === "idle" &&
+          (processesRunning.gateway === "Enabled" ||
+            processesRunning.tunnel === "Enabled") && (
+            <button
+              onClick={() => {
+                void invoke("kill_host_processes").then(() =>
+                  setProcessesRunning({
+                    gateway: "Disabled",
+                    tunnel: "Disabled",
+                  }),
+                );
+              }}
+              style={{
+                marginTop: 8,
+                fontSize: 12,
+                fontFamily: "monospace",
+                fontWeight: 600,
+                padding: "5px 16px",
+                borderRadius: 5,
+                border: "none",
+                background: "linear-gradient(135deg, #e67e22, #d35400)",
+                color: "#fff",
+                cursor: "pointer",
+                boxShadow: "0 2px 8px rgba(230,126,34,0.35)",
+                letterSpacing: "0.03em",
+              }}
+            >
+              ⏹ Kill Processes
+            </button>
+          )}
+        {sessionStatus === "idle" && (
+          <div style={{ display: "flex", gap: 10, marginTop: 8 }}>
+            <button
+              onClick={() => void handleHostClick()}
+              disabled={sessionBusy}
+              style={{
+                fontSize: 12,
+                fontFamily: "monospace",
+                fontWeight: 600,
+                padding: "5px 16px",
+                borderRadius: 5,
+                border: "none",
+                background: sessionBusy
+                  ? "#2a4a3a"
+                  : "linear-gradient(135deg, #2ecc71, #27ae60)",
+                color: sessionBusy ? "#6a9a7a" : "#fff",
+                cursor: sessionBusy ? "not-allowed" : "pointer",
+                boxShadow: sessionBusy
+                  ? "none"
+                  : "0 2px 8px rgba(46,204,113,0.3)",
+                transition: "all 0.15s",
+                letterSpacing: "0.03em",
+              }}
+            >
+              {sessionBusy ? "⏳ Starting…" : "⚡ Host Session"}
+            </button>
+            {!sessionBusy && (
+              <button
+                onClick={() => void handleJoinClick()}
+                style={{
+                  fontSize: 12,
+                  fontFamily: "monospace",
+                  fontWeight: 600,
+                  padding: "5px 16px",
+                  borderRadius: 5,
+                  border: "none",
+                  background: "linear-gradient(135deg, #3498db, #2980b9)",
+                  color: "#fff",
+                  cursor: "pointer",
+                  boxShadow: "0 2px 8px rgba(52,152,219,0.3)",
+                  transition: "all 0.15s",
+                  letterSpacing: "0.03em",
+                }}
+              >
+                🔗 Join Session
+              </button>
+            )}
+          </div>
+        )}
+        {sessionEndedBanner && (
+          <div
+            style={{
+              marginTop: 6,
+              padding: "5px 12px",
+              borderRadius: 5,
+              background: "#2a1a0a",
+              border: "1px solid #e67e22",
+              color: "#e67e22",
+              fontSize: 12,
+              fontFamily: "monospace",
+            }}
+          >
+            ⚠ The host ended the session. Your document is preserved.
+          </div>
+        )}
+        {sessionStatus === "host" && (
+          <button
+            onClick={() => {
+              void invoke("end_session").then(() => {
+                setSessionStatus("idle");
+                setLanUrl(null);
+                setPublicUrl(null);
+              });
+            }}
+            style={{
+              marginTop: 8,
+              fontSize: 12,
+              fontFamily: "monospace",
+              fontWeight: 600,
+              padding: "5px 16px",
+              borderRadius: 5,
+              border: "none",
+              background: "linear-gradient(135deg, #e74c3c, #c0392b)",
+              color: "#fff",
+              cursor: "pointer",
+              boxShadow: "0 2px 8px rgba(231,76,60,0.3)",
+              letterSpacing: "0.03em",
+            }}
+          >
+            ✕ End Session
+          </button>
+        )}
+        {sessionStatus === "guest" && (
+          <button
+            onClick={() => {
+              void invoke("leave_session").then(() => {
+                setSessionStatus("idle");
+                setPublicUrl(null);
+              });
+            }}
+            style={{
+              marginTop: 8,
+              fontSize: 12,
+              fontFamily: "monospace",
+              fontWeight: 600,
+              padding: "5px 16px",
+              borderRadius: 5,
+              border: "none",
+              background: "linear-gradient(135deg, #e74c3c, #c0392b)",
+              color: "#fff",
+              cursor: "pointer",
+              boxShadow: "0 2px 8px rgba(231,76,60,0.3)",
+              letterSpacing: "0.03em",
+            }}
+          >
+            ✕ Leave Session
+          </button>
         )}
       </div>
       <div className="editor-container">
@@ -351,6 +859,22 @@ function AppContent({ username }: AppContentProps) {
           </div>
         ))}
       </div>
+      {showSavePrompt && (
+        <SaveBeforeSessionModal
+          onSaveAndContinue={handleSaveAndContinue}
+          onDiscardAndContinue={() => void handleDiscardAndContinue()}
+          onCancel={() => {
+            setShowSavePrompt(false);
+            setPendingAction(null);
+          }}
+        />
+      )}
+      {showJoinModal && (
+        <JoinModal
+          onSuccess={() => void handleJoinSuccess()}
+          onCancel={() => setShowJoinModal(false)}
+        />
+      )}
     </>
   );
 }

--- a/tauri-app/src/sessionSetup.tsx
+++ b/tauri-app/src/sessionSetup.tsx
@@ -24,7 +24,7 @@ export function SessionSetupModal({ onDone }: SessionSetupModalProps) {
     setBusy(true);
     setError("");
     try {
-      await invoke("start_host_session");
+      await invoke("host_session");
       onDone();
     } catch (err) {
       setError(String(err));

--- a/tauri-app/src/usernameSetup.tsx
+++ b/tauri-app/src/usernameSetup.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, type FormEvent } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type React from "react";
-import { SessionSetupModal } from "./sessionSetup";
 
 const MAX_LEN = 32;
 
@@ -72,7 +71,6 @@ interface UsernameGateProps {
 
 export function UsernameGate({ children }: UsernameGateProps) {
   const [username, setUsername] = useState<string | null>(null);
-  const [sessionReady, setSessionReady] = useState(false);
 
   useEffect(() => {
     invoke<{ username: string | null }>("get_identity")
@@ -82,8 +80,6 @@ export function UsernameGate({ children }: UsernameGateProps) {
 
   if (username === null) return null;
   if (username === "") return <FirstRunModal onDone={setUsername} />;
-  if (!sessionReady)
-    return <SessionSetupModal onDone={() => setSessionReady(true)} />;
   return <>{children(username)}</>;
 }
 


### PR DESCRIPTION
* decoupled process spawning from frontend emitting and room creation
* introduced a new gateway api layer that abstracts away gateway http communication
* moved host session commands and guest session commands in separate files
* moved process logger in a separate file
* Created a new Sidecar struct tu abstract some process spawning
* Created a feature to leave a session
* decoupled session ending and process killing
* implemented a feature to end session gracefully
* enhanced frontend
* implemented a flow to remove the room from go gateway
* modified make dev to use vite dev features
* updated dependency versions to fix vulnurabilities
* changed the debug logger tu rin in tokyo async task thread