### PR TITLE
implement snapshot distribution to new clients

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/crdt-core/src/lib.rs
+++ b/crdt-core/src/lib.rs
@@ -9,4 +9,7 @@ pub mod wire;
 pub use document::{Document, RemoteChange};
 pub use error::DocumentError;
 pub use snapshot::{Snapshot, SnapshotBlock, SnapshotError};
-pub use wire::{OP_PREFIX, OpMessage, SNAPSHOT_PREFIX, WireBlock, WireError, decode_op, encode_op};
+pub use wire::{
+    OP_PREFIX, OpMessage, SNAPSHOT_PREFIX, WireBlock, WireError, decode_op, decode_snapshot,
+    encode_op, encode_snapshot,
+};

--- a/crdt-core/src/wire.rs
+++ b/crdt-core/src/wire.rs
@@ -1,3 +1,4 @@
+use crate::snapshot::{Snapshot, SnapshotError};
 use crate::store::DeleteSet;
 use crate::structs::Block;
 use crate::types::BlockId;
@@ -44,7 +45,9 @@ pub enum WireError {
     EmptyFrame,
     UnknownPrefix(u8),
     NotAnOp,
+    NotASnapshot,
     Decode(bitcode::Error),
+    SnapshotDecode(SnapshotError),
 }
 
 impl fmt::Display for WireError {
@@ -57,7 +60,11 @@ impl fmt::Display for WireError {
             WireError::NotAnOp => {
                 write!(f, "wire frame carries a snapshot, not an op")
             }
+            WireError::NotASnapshot => {
+                write!(f, "wire frame carries an op, not a snapshot")
+            }
             WireError::Decode(e) => write!(f, "bitcode decode failed: {e}"),
+            WireError::SnapshotDecode(e) => write!(f, "snapshot decode failed: {e}"),
         }
     }
 }
@@ -66,6 +73,7 @@ impl Error for WireError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             WireError::Decode(e) => Some(e),
+            WireError::SnapshotDecode(e) => Some(e),
             _ => None,
         }
     }
@@ -86,9 +94,27 @@ pub fn decode_op(frame: &[u8]) -> Result<OpMessage, WireError> {
     let (&prefix, payload) = frame.split_first().ok_or(WireError::EmptyFrame)?;
     match prefix {
         OP_PREFIX => bitcode::decode(payload).map_err(WireError::Decode),
-        // TODO(T15): route through a snapshot decoder once the snapshot
-        // format lands;
         SNAPSHOT_PREFIX => Err(WireError::NotAnOp),
+        b => Err(WireError::UnknownPrefix(b)),
+    }
+}
+
+pub fn encode_snapshot(snap: &Snapshot) -> Vec<u8> {
+    trace!("encode snapshot requested");
+    let payload = snap.encode();
+    let mut frame = Vec::with_capacity(1 + payload.len());
+    frame.push(SNAPSHOT_PREFIX);
+    frame.extend_from_slice(&payload);
+    trace!("encode snapshot frame: {} bytes", frame.len());
+    frame
+}
+
+pub fn decode_snapshot(frame: &[u8]) -> Result<Snapshot, WireError> {
+    trace!("decode snapshot requested: {} bytes", frame.len());
+    let (&prefix, payload) = frame.split_first().ok_or(WireError::EmptyFrame)?;
+    match prefix {
+        SNAPSHOT_PREFIX => Snapshot::decode(payload).map_err(WireError::SnapshotDecode),
+        OP_PREFIX => Err(WireError::NotASnapshot),
         b => Err(WireError::UnknownPrefix(b)),
     }
 }

--- a/crdt-core/src/wire/tests.rs
+++ b/crdt-core/src/wire/tests.rs
@@ -104,3 +104,49 @@ fn wire_error_display_has_stable_text() {
     let e = WireError::EmptyFrame;
     assert!(!format!("{e}").is_empty());
 }
+
+#[test]
+fn encode_decode_snapshot_round_trips() {
+    use crate::snapshot::{SNAPSHOT_VERSION, Snapshot, SnapshotBlock};
+
+    let snap = Snapshot {
+        version: SNAPSHOT_VERSION,
+        client_id: ClientId::new(42),
+        blocks: vec![SnapshotBlock {
+            id: bid(42, 0),
+            origin_left: None,
+            origin_right: None,
+            left: None,
+            right: None,
+            content: "hello".to_string(),
+            is_deleted: false,
+        }],
+        state_vector: vec![(ClientId::new(42), 1)],
+        delete_set: DeleteSet::new(),
+        seen_delete_set: DeleteSet::new(),
+        head: Some(bid(42, 0)),
+        pending_blocks: vec![],
+        pending_delete_sets: vec![],
+    };
+    let frame = encode_snapshot(&snap);
+    assert_eq!(frame[0], SNAPSHOT_PREFIX);
+    let decoded = decode_snapshot(&frame).expect("decode");
+    assert_eq!(decoded.version, SNAPSHOT_VERSION);
+    assert_eq!(decoded.client_id, snap.client_id);
+    assert_eq!(decoded.blocks.len(), 1);
+    assert_eq!(decoded.blocks[0].content, "hello");
+}
+
+#[test]
+fn decode_snapshot_rejects_op_prefix() {
+    let frame = vec![OP_PREFIX, 0x00];
+    assert!(matches!(
+        decode_snapshot(&frame),
+        Err(WireError::NotASnapshot)
+    ));
+}
+
+#[test]
+fn decode_snapshot_rejects_empty_frame() {
+    assert!(matches!(decode_snapshot(&[]), Err(WireError::EmptyFrame)));
+}

--- a/gateway/internal/client/client.go
+++ b/gateway/internal/client/client.go
@@ -47,6 +47,11 @@ func (c *Client) Send(data []byte) (ok bool) {
 	}
 }
 
+// for testing only
+func (c *Client) SendChan() <-chan []byte {
+	return c.send
+}
+
 func (c *Client) ForceClose() {
 	if c.conn == nil {
 		slog.Debug("force-close skipped: client connection is nil", "room_id", c.RoomID, "client_id", c.ID)

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -116,7 +116,7 @@ func readWSParams(w http.ResponseWriter, r *http.Request) (roomID, clientID stri
 }
 
 func dispatchFrame(rm *room.Room, sender *client.Client, raw []byte) {
-	if _, err := wire.DecodeOpFrame(raw); err != nil {
+	if err := wire.ValidateFrame(raw); err != nil {
 		slog.Warn(
 			"dropping invalid frame",
 			"room_id", rm.ID,
@@ -178,6 +178,10 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		h.unregister(c, rm)
 		slog.Info("client left room", "room_id", roomID, "client_id", clientID)
 	}()
+
+	if rm.ReplayTo(c) {
+		slog.Info("snapshot replayed to joiner", "room_id", roomID, "client_id", clientID)
+	}
 
 	ctx := r.Context()
 	ops := make(chan []byte, stagingOpsBuffer)

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -168,13 +168,13 @@ func (r *Room) BroadcastAll(data []byte) {
 
 func (r *Room) getPeers(exclude *client.Client) []*client.Client {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	targets := make([]*client.Client, 0, len(r.clients))
 	for c := range r.clients {
 		if exclude == nil || c != exclude {
 			targets = append(targets, c)
 		}
 	}
-	r.mu.Unlock()
 	return targets
 }
 

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"gateway/internal/client"
+	"gateway/internal/wire"
 )
 
 const opsBufferSize = 256
@@ -20,6 +21,9 @@ type Room struct {
 	mu      sync.Mutex
 	clients map[*client.Client]struct{}
 	closed  bool
+
+	latestSnapshot []byte
+	opsLog         [][]byte
 
 	ops  chan BroadcastMsg
 	done chan struct{}
@@ -77,6 +81,53 @@ func (r *Room) Size() int {
 	return len(r.clients)
 }
 
+func (r *Room) StoreSnapshot(data []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.latestSnapshot = make([]byte, len(data))
+	copy(r.latestSnapshot, data)
+	r.opsLog = nil
+	slog.Info("snapshot stored", "room_id", r.ID, "bytes", len(data))
+}
+
+func (r *Room) AppendOp(data []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.latestSnapshot == nil {
+		return
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	r.opsLog = append(r.opsLog, cp)
+}
+
+func (r *Room) ReplayTo(c *client.Client) bool {
+	r.mu.Lock()
+	snap := r.latestSnapshot
+	ops := make([][]byte, len(r.opsLog))
+	copy(ops, r.opsLog)
+	r.mu.Unlock()
+
+	if snap == nil {
+		slog.Debug("replay skipped: no snapshot available", "room_id", r.ID, "client_id", c.ID)
+		return false
+	}
+
+	if !c.Send(snap) {
+		slog.Warn("replay: failed to send snapshot to joiner", "room_id", r.ID, "client_id", c.ID)
+		return false
+	}
+	slog.Info("replay: snapshot sent to joiner", "room_id", r.ID, "client_id", c.ID, "snapshot_bytes", len(snap), "buffered_ops", len(ops))
+
+	for i, op := range ops {
+		if !c.Send(op) {
+			slog.Warn("replay: failed to send buffered op to joiner", "room_id", r.ID, "client_id", c.ID, "op_index", i)
+			break
+		}
+	}
+	return true
+}
+
 func (r *Room) Run() {
 	slog.Info("room loop started", "room_id", r.ID)
 	for {
@@ -87,20 +138,18 @@ func (r *Room) Run() {
 			slog.Info("room loop stopped", "room_id", r.ID)
 			return
 		case msg := <-r.ops:
-			r.broadcast(msg)
+			if wire.IsSnapshotFrame(msg.Data) {
+				r.StoreSnapshot(msg.Data)
+			} else {
+				r.AppendOp(msg.Data)
+				r.broadcast(msg)
+			}
 		}
 	}
 }
 
 func (r *Room) broadcast(msg BroadcastMsg) {
-	r.mu.Lock()
-	targets := make([]*client.Client, 0, len(r.clients))
-	for c := range r.clients {
-		if c != msg.Sender {
-			targets = append(targets, c)
-		}
-	}
-	r.mu.Unlock()
+	targets := r.getPeers(msg.Sender)
 
 	slog.Debug(
 		"broadcast dispatch prepared",
@@ -109,9 +158,30 @@ func (r *Room) broadcast(msg BroadcastMsg) {
 		"targets", len(targets),
 		"bytes", len(msg.Data),
 	)
+	r.sendToPeers(targets, msg.Data, "disconnecting slow client")
+}
+
+func (r *Room) BroadcastAll(data []byte) {
+	targets := r.getPeers(nil)
+	r.sendToPeers(targets, data, "slow client during BroadcastAll; force-closing")
+}
+
+func (r *Room) getPeers(exclude *client.Client) []*client.Client {
+	r.mu.Lock()
+	targets := make([]*client.Client, 0, len(r.clients))
+	for c := range r.clients {
+		if exclude == nil || c != exclude {
+			targets = append(targets, c)
+		}
+	}
+	r.mu.Unlock()
+	return targets
+}
+
+func (r *Room) sendToPeers(targets []*client.Client, data []byte, slowClientLogMsg string) {
 	for _, c := range targets {
-		if !c.Send(msg.Data) {
-			slog.Warn("disconnecting slow client", "room_id", r.ID, "client_id", c.ID)
+		if !c.Send(data) {
+			slog.Warn(slowClientLogMsg, "room_id", r.ID, "client_id", c.ID)
 			c.ForceClose()
 		}
 	}

--- a/gateway/internal/room/room_test.go
+++ b/gateway/internal/room/room_test.go
@@ -98,3 +98,54 @@ func TestRoom_JoinAfterCloseIsRejected(t *testing.T) {
 
 	<-runDone
 }
+
+func TestRoom_SnapshotReplayToJoiner(t *testing.T) {
+	r := New("room-snap")
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	host := client.New("host", "room-snap", nil)
+	r.Join(host)
+
+	snapFrame := []byte{0x01, 0xAA, 0xBB}
+	r.Ops() <- BroadcastMsg{Sender: host, Data: snapFrame}
+	time.Sleep(50 * time.Millisecond)
+
+	op1 := []byte{0x00, 0x01}
+	op2 := []byte{0x00, 0x02}
+	r.Ops() <- BroadcastMsg{Sender: host, Data: op1}
+	r.Ops() <- BroadcastMsg{Sender: host, Data: op2}
+	time.Sleep(50 * time.Millisecond)
+
+	joiner := client.New("joiner", "room-snap", nil)
+	r.Join(joiner)
+
+	got := r.ReplayTo(joiner)
+	if !got {
+		t.Fatal("ReplayTo returned false; expected snapshot replay")
+	}
+
+	var received [][]byte
+	for {
+		select {
+		case msg := <-joiner.SendChan():
+			received = append(received, msg)
+		default:
+			goto done
+		}
+	}
+done:
+	if len(received) != 3 {
+		t.Fatalf("joiner received %d messages, want 3 (snapshot + 2 ops)", len(received))
+	}
+	if received[0][0] != 0x01 {
+		t.Fatalf("first message prefix = 0x%02X, want 0x01 (snapshot)", received[0][0])
+	}
+	if received[1][0] != 0x00 || received[2][0] != 0x00 {
+		t.Fatalf("op messages have wrong prefix")
+	}
+
+	r.Leave(host, nil)
+	r.Leave(joiner, nil)
+	<-runDone
+}

--- a/gateway/internal/wire/wire.go
+++ b/gateway/internal/wire/wire.go
@@ -11,10 +11,21 @@ const (
 )
 
 var (
-	ErrEmptyFrame           = errors.New("wire: empty frame")
-	ErrUnknownPrefix        = errors.New("wire: unknown prefix")
-	ErrSnapshotNotSupported = errors.New("wire: snapshot frames not yet supported")
+	ErrEmptyFrame    = errors.New("wire: empty frame")
+	ErrUnknownPrefix = errors.New("wire: unknown prefix")
 )
+
+func ValidateFrame(frame []byte) error {
+	if len(frame) == 0 {
+		return ErrEmptyFrame
+	}
+	switch frame[0] {
+	case PrefixOp, PrefixSnapshot:
+		return nil
+	default:
+		return fmt.Errorf("%w: 0x%02X", ErrUnknownPrefix, frame[0])
+	}
+}
 
 func DecodeOpFrame(frame []byte) ([]byte, error) {
 	if len(frame) == 0 {
@@ -23,13 +34,15 @@ func DecodeOpFrame(frame []byte) ([]byte, error) {
 	switch frame[0] {
 	case PrefixOp:
 		return frame[1:], nil
-	// TODO(T15/T16): route snapshot frames (host → joiner) once the
-	// snapshot format and per-room cache land.
 	case PrefixSnapshot:
-		return nil, ErrSnapshotNotSupported
+		return nil, fmt.Errorf("wire: expected op frame, got snapshot")
 	default:
 		return nil, fmt.Errorf("%w: 0x%02X", ErrUnknownPrefix, frame[0])
 	}
+}
+
+func IsSnapshotFrame(frame []byte) bool {
+	return len(frame) > 0 && frame[0] == PrefixSnapshot
 }
 
 func EncodeOpFrame(payload []byte) []byte {

--- a/gateway/internal/wire/wire_test.go
+++ b/gateway/internal/wire/wire_test.go
@@ -45,10 +45,10 @@ func TestDecodeOpFrame_UnknownPrefix(t *testing.T) {
 	}
 }
 
-func TestDecodeOpFrame_SnapshotPrefixIsReserved(t *testing.T) {
+func TestDecodeOpFrame_SnapshotPrefixRejectsAsOp(t *testing.T) {
 	_, err := DecodeOpFrame([]byte{PrefixSnapshot, 0x00})
-	if !errors.Is(err, ErrSnapshotNotSupported) {
-		t.Fatalf("err = %v, want ErrSnapshotNotSupported", err)
+	if err == nil {
+		t.Fatal("expected error for snapshot prefix, got nil")
 	}
 }
 
@@ -64,5 +64,38 @@ func TestEncodeOpFrame_RoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("payload = %x, want %x", got, payload)
+	}
+}
+
+func TestValidateFrame_AcceptsOpAndSnapshot(t *testing.T) {
+	if err := ValidateFrame([]byte{PrefixOp, 0x00}); err != nil {
+		t.Fatalf("ValidateFrame(op) = %v, want nil", err)
+	}
+	if err := ValidateFrame([]byte{PrefixSnapshot, 0x00}); err != nil {
+		t.Fatalf("ValidateFrame(snapshot) = %v, want nil", err)
+	}
+}
+
+func TestValidateFrame_RejectsUnknown(t *testing.T) {
+	if err := ValidateFrame([]byte{0xFF}); !errors.Is(err, ErrUnknownPrefix) {
+		t.Fatalf("ValidateFrame(0xFF) = %v, want ErrUnknownPrefix", err)
+	}
+}
+
+func TestValidateFrame_RejectsEmpty(t *testing.T) {
+	if err := ValidateFrame(nil); !errors.Is(err, ErrEmptyFrame) {
+		t.Fatalf("ValidateFrame(nil) = %v, want ErrEmptyFrame", err)
+	}
+}
+
+func TestIsSnapshotFrame(t *testing.T) {
+	if !IsSnapshotFrame([]byte{PrefixSnapshot, 0x01}) {
+		t.Fatal("IsSnapshotFrame should return true for snapshot prefix")
+	}
+	if IsSnapshotFrame([]byte{PrefixOp, 0x01}) {
+		t.Fatal("IsSnapshotFrame should return false for op prefix")
+	}
+	if IsSnapshotFrame(nil) {
+		t.Fatal("IsSnapshotFrame should return false for nil")
 	}
 }

--- a/tauri-app/src-tauri/src/crdt/local_op_handler.rs
+++ b/tauri-app/src-tauri/src/crdt/local_op_handler.rs
@@ -2,7 +2,7 @@ use crdt_core::wire::{encode_op, OpMessage};
 use log::{debug, error, info};
 use tauri::State;
 
-use crate::state::appstate::AppState;
+use crate::state::appstate::{AppRole, AppState};
 use crate::state::ws_state::WsState;
 use std::sync::atomic::Ordering;
 
@@ -93,22 +93,20 @@ pub async fn delete(
 }
 
 async fn maybe_send_snapshot(state: &State<'_, AppState>, ws: &State<'_, WsState>) {
-    if !matches!(
-        *state.role.lock().unwrap(),
-        crate::state::appstate::AppRole::Host { .. }
-    ) {
+    if !matches!(*state.role.lock().unwrap(), AppRole::Host { .. }) {
         return;
     }
     let count = state.ops_since_snapshot.fetch_add(1, Ordering::Relaxed) + 1;
-    if count >= SNAPSHOT_REFRESH_INTERVAL {
-        state.ops_since_snapshot.store(0, Ordering::Relaxed);
-        let snapshot_frame = {
-            let doc = state.document.lock().unwrap();
-            crdt_core::encode_snapshot(&doc.to_snapshot())
-        };
-        ws.send_raw(snapshot_frame).await;
-        info!("periodic snapshot sent (after {} ops)", count);
+    if count < SNAPSHOT_REFRESH_INTERVAL {
+        return;
     }
+    state.ops_since_snapshot.store(0, Ordering::Relaxed);
+    let snapshot_frame = {
+        let doc = state.document.lock().unwrap();
+        crdt_core::encode_snapshot(&doc.to_snapshot())
+    };
+    ws.send_raw(snapshot_frame).await;
+    info!("periodic snapshot sent (after {} ops)", count);
 }
 
 #[cfg(debug_assertions)]

--- a/tauri-app/src-tauri/src/crdt/local_op_handler.rs
+++ b/tauri-app/src-tauri/src/crdt/local_op_handler.rs
@@ -1,10 +1,12 @@
 use crdt_core::wire::{encode_op, OpMessage};
-use log::{debug, error};
+use log::{debug, error, info};
 use tauri::State;
 
 use crate::state::appstate::AppState;
 use crate::state::ws_state::WsState;
 use std::sync::atomic::Ordering;
+
+const SNAPSHOT_REFRESH_INTERVAL: u32 = 100;
 
 #[tauri::command]
 pub async fn insert(
@@ -44,6 +46,7 @@ pub async fn insert(
     if let Some(wire_block) = wire_block_opt {
         let frame = encode_op(&OpMessage::Insert(wire_block));
         ws.send_raw(frame).await;
+        maybe_send_snapshot(&state, &ws).await;
     }
 
     Ok(())
@@ -83,9 +86,29 @@ pub async fn delete(
     if !delete_set.is_empty() {
         let frame = encode_op(&OpMessage::Delete(delete_set));
         ws.send_raw(frame).await;
+        maybe_send_snapshot(&state, &ws).await;
     }
 
     Ok(())
+}
+
+async fn maybe_send_snapshot(state: &State<'_, AppState>, ws: &State<'_, WsState>) {
+    if !matches!(
+        *state.role.lock().unwrap(),
+        crate::state::appstate::AppRole::Host { .. }
+    ) {
+        return;
+    }
+    let count = state.ops_since_snapshot.fetch_add(1, Ordering::Relaxed) + 1;
+    if count >= SNAPSHOT_REFRESH_INTERVAL {
+        state.ops_since_snapshot.store(0, Ordering::Relaxed);
+        let snapshot_frame = {
+            let doc = state.document.lock().unwrap();
+            crdt_core::encode_snapshot(&doc.to_snapshot())
+        };
+        ws.send_raw(snapshot_frame).await;
+        info!("periodic snapshot sent (after {} ops)", count);
+    }
 }
 
 #[cfg(debug_assertions)]

--- a/tauri-app/src-tauri/src/crdt/remote_op_handler.rs
+++ b/tauri-app/src-tauri/src/crdt/remote_op_handler.rs
@@ -1,15 +1,16 @@
 use crdt_core::store::DeleteSet;
 use crdt_core::structs::Block;
 use crdt_core::wire::WireBlock;
-use crdt_core::{decode_op, Document, OpMessage, RemoteChange};
+use crdt_core::{decode_op, decode_snapshot, Document, OpMessage, RemoteChange, SNAPSHOT_PREFIX};
 use log::{debug, error, info, warn};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::state::appstate::AppState;
-use crate::ws_management::ws_types::RemoteChangeEvent;
+use crate::ws_management::ws_types::{RemoteChangeEvent, SnapshotAppliedEvent};
 
 pub const REMOTE_CHANGE_EVENT: &str = "crdt://remote-change";
+pub const SNAPSHOT_APPLIED_EVENT: &str = "crdt://snapshot-applied";
 
 pub async fn process_loop(mut rx: UnboundedReceiver<Vec<u8>>, app: AppHandle) {
     info!("op processor loop started");
@@ -20,6 +21,38 @@ pub async fn process_loop(mut rx: UnboundedReceiver<Vec<u8>>, app: AppHandle) {
 }
 
 pub fn handle_remote_binary(app: &AppHandle, bytes: &[u8]) {
+    if bytes.first().copied() == Some(SNAPSHOT_PREFIX) {
+        handle_snapshot(app, bytes);
+    } else {
+        handle_op(app, bytes);
+    }
+}
+
+fn handle_snapshot(app: &AppHandle, bytes: &[u8]) {
+    let snap = match decode_snapshot(bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("snapshot decode failed: {e}");
+            return;
+        }
+    };
+
+    let text = {
+        let state = app.state::<AppState>();
+        let mut doc = state.document.lock().unwrap();
+        let local_client_id = doc.client_id;
+        let forked = Document::from_snapshot(snap).fork(local_client_id);
+        *doc = forked;
+        doc.get_text()
+    };
+
+    info!("snapshot applied: text_len={}", text.len());
+    if let Err(e) = app.emit(SNAPSHOT_APPLIED_EVENT, SnapshotAppliedEvent { text }) {
+        warn!("failed to emit snapshot-applied event: {e}");
+    }
+}
+
+fn handle_op(app: &AppHandle, bytes: &[u8]) {
     let op = match decode_op(bytes) {
         Ok(op) => op,
         Err(e) => {

--- a/tauri-app/src-tauri/src/crdt/remote_op_handler.rs
+++ b/tauri-app/src-tauri/src/crdt/remote_op_handler.rs
@@ -9,8 +9,8 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use crate::state::appstate::AppState;
 use crate::ws_management::ws_types::{RemoteChangeEvent, SnapshotAppliedEvent};
 
-pub const REMOTE_CHANGE_EVENT: &str = "crdt://remote-change";
-pub const SNAPSHOT_APPLIED_EVENT: &str = "crdt://snapshot-applied";
+const REMOTE_CHANGE_EVENT: &str = "crdt://remote-change";
+const SNAPSHOT_APPLIED_EVENT: &str = "crdt://snapshot-applied";
 
 pub async fn process_loop(mut rx: UnboundedReceiver<Vec<u8>>, app: AppHandle) {
     info!("op processor loop started");

--- a/tauri-app/src-tauri/src/session/command.rs
+++ b/tauri-app/src-tauri/src/session/command.rs
@@ -236,5 +236,17 @@ async fn connect(app: AppHandle, port: u16, room_id: String) {
             "local websocket connection established for host session: room_id={}",
             room_id
         );
+
+        let snapshot_frame = {
+            let state = app.state::<AppState>();
+            let doc = state.document.lock().unwrap();
+            let snap = doc.to_snapshot();
+            crdt_core::encode_snapshot(&snap)
+        };
+        ws.send_raw(snapshot_frame).await;
+        app.state::<AppState>()
+            .ops_since_snapshot
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        info!("host sent initial document snapshot to gateway");
     }
 }

--- a/tauri-app/src-tauri/src/session/host_commands.rs
+++ b/tauri-app/src-tauri/src/session/host_commands.rs
@@ -180,5 +180,17 @@ async fn connect(app: AppHandle, port: u16, room_id: String) {
             "local websocket connection established for host session: room_id={}",
             room_id
         );
+
+        let snapshot_frame = {
+            let state = app.state::<AppState>();
+            let doc = state.document.lock().unwrap();
+            let snap = doc.to_snapshot();
+            crdt_core::encode_snapshot(&snap)
+        };
+        ws.send_raw(snapshot_frame).await;
+        app.state::<AppState>()
+            .ops_since_snapshot
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        info!("host sent initial document snapshot to gateway");
     }
 }

--- a/tauri-app/src-tauri/src/session/host_commands.rs
+++ b/tauri-app/src-tauri/src/session/host_commands.rs
@@ -180,17 +180,20 @@ async fn connect(app: AppHandle, port: u16, room_id: String) {
             "local websocket connection established for host session: room_id={}",
             room_id
         );
-
-        let snapshot_frame = {
-            let state = app.state::<AppState>();
-            let doc = state.document.lock().unwrap();
-            let snap = doc.to_snapshot();
-            crdt_core::encode_snapshot(&snap)
-        };
-        ws.send_raw(snapshot_frame).await;
-        app.state::<AppState>()
-            .ops_since_snapshot
-            .store(0, std::sync::atomic::Ordering::Relaxed);
-        info!("host sent initial document snapshot to gateway");
+        send_initial_snapshot(&app).await;
     }
+}
+
+async fn send_initial_snapshot(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    let ws = app.state::<WsState>();
+    let snapshot_frame = {
+        let doc = state.document.lock().unwrap();
+        crdt_core::encode_snapshot(&doc.to_snapshot())
+    };
+    ws.send_raw(snapshot_frame).await;
+    state
+        .ops_since_snapshot
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    info!("host sent initial document snapshot to gateway");
 }

--- a/tauri-app/src-tauri/src/state/appstate.rs
+++ b/tauri-app/src-tauri/src/state/appstate.rs
@@ -1,7 +1,7 @@
 use crdt_core::types::ClientId;
 use crdt_core::Document;
 use log::{info, warn};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::sync::Mutex;
 use tauri_plugin_shell::process::CommandChild;
 
@@ -10,6 +10,7 @@ pub struct AppState {
     pub role: Mutex<AppRole>,
     pub processes: Mutex<HostProcesses>,
     pub current_document_name: Mutex<Option<String>>,
+    pub ops_since_snapshot: AtomicU32,
     #[cfg(debug_assertions)]
     pub crdt_logging_enabled: AtomicBool,
 }
@@ -58,6 +59,7 @@ impl AppState {
                 tunnel: None,
             }),
             current_document_name: Mutex::new(None),
+            ops_since_snapshot: AtomicU32::new(0),
             #[cfg(debug_assertions)]
             crdt_logging_enabled: AtomicBool::new(false),
         }

--- a/tauri-app/src-tauri/src/ws_management/ws_types.rs
+++ b/tauri-app/src-tauri/src/ws_management/ws_types.rs
@@ -42,6 +42,11 @@ impl From<RemoteChange> for RemoteChangeEvent {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct SnapshotAppliedEvent {
+    pub text: String,
+}
+
 #[derive(Debug)]
 pub enum WsError {
     AlreadyConnected,

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -123,6 +123,48 @@ function AppContent({ username }: AppContentProps) {
     setEventLog,
   });
 
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+
+    listen<{ text: string }>("crdt://snapshot-applied", (e) => {
+      const ed = editorRef.current;
+      if (!ed) return;
+
+      isApplyingRemote.current = true;
+      try {
+        ed.setValue(e.payload.text);
+      } finally {
+        isApplyingRemote.current = false;
+      }
+
+      const count = ++eventCountRef.current;
+      setEventLog((prev) => [
+        ...prev,
+        {
+          id: count,
+          operationClass: "op-snapshot",
+          operationLabel: "[snapshot-applied]",
+          payload: `text_len=${e.payload.text.length}`,
+        },
+      ]);
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) {
+        unlisten();
+        unlisten = null;
+      }
+    };
+  }, [editorRef, isApplyingRemote, eventCountRef, setEventLog]);
+
   const [loggingEnabled, setLoggingEnabled] = useState(false);
   const toggleLogging = async () => {
     if (!isDevFeaturesEnabled) return;

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -10,6 +10,7 @@ import Editor, { type OnMount, type Monaco } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useRemoteChangeListener } from "./remoteChangeListener";
+import { useSnapshotListener } from "./snapshotListener";
 import {
   UsernameGate,
   overlayStyle,
@@ -407,47 +408,12 @@ function AppContent({ username }: AppContentProps) {
     setEventLog,
   });
 
-  useEffect(() => {
-    let unlisten: (() => void) | null = null;
-    let cancelled = false;
-
-    listen<{ text: string }>("crdt://snapshot-applied", (e) => {
-      const ed = editorRef.current;
-      if (!ed) return;
-
-      isApplyingRemote.current = true;
-      try {
-        ed.setValue(e.payload.text);
-      } finally {
-        isApplyingRemote.current = false;
-      }
-
-      const count = ++eventCountRef.current;
-      setEventLog((prev) => [
-        ...prev,
-        {
-          id: count,
-          operationClass: "op-snapshot",
-          operationLabel: "[snapshot-applied]",
-          payload: `text_len=${e.payload.text.length}`,
-        },
-      ]);
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisten = fn;
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      if (unlisten) {
-        unlisten();
-        unlisten = null;
-      }
-    };
-  }, [editorRef, isApplyingRemote, eventCountRef, setEventLog]);
+  useSnapshotListener({
+    editorRef,
+    isApplyingRemote,
+    eventCountRef,
+    setEventLog,
+  });
 
   const [loggingEnabled, setLoggingEnabled] = useState(false);
   const toggleLogging = async () => {

--- a/tauri-app/src/snapshotListener.ts
+++ b/tauri-app/src/snapshotListener.ts
@@ -1,0 +1,71 @@
+import {
+  useEffect,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import type { editor } from "monaco-editor";
+import { listen } from "@tauri-apps/api/event";
+
+interface LogEntry {
+  id: number;
+  operationClass: string;
+  operationLabel: string;
+  payload: string;
+}
+
+interface UseSnapshotListenerArgs {
+  editorRef: MutableRefObject<editor.IStandaloneCodeEditor | null>;
+  isApplyingRemote: MutableRefObject<boolean>;
+  eventCountRef: MutableRefObject<number>;
+  setEventLog: Dispatch<SetStateAction<LogEntry[]>>;
+}
+
+export function useSnapshotListener({
+  editorRef,
+  isApplyingRemote,
+  eventCountRef,
+  setEventLog,
+}: UseSnapshotListenerArgs) {
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+
+    listen<{ text: string }>("crdt://snapshot-applied", (e) => {
+      const ed = editorRef.current;
+      if (!ed) return;
+
+      isApplyingRemote.current = true;
+      try {
+        ed.setValue(e.payload.text);
+      } finally {
+        isApplyingRemote.current = false;
+      }
+
+      const count = ++eventCountRef.current;
+      setEventLog((prev) => [
+        ...prev,
+        {
+          id: count,
+          operationClass: "op-snapshot",
+          operationLabel: "[snapshot-applied]",
+          payload: `text_len=${e.payload.text.length}`,
+        },
+      ]);
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) {
+        unlisten();
+        unlisten = null;
+      }
+    };
+  }, [editorRef, isApplyingRemote, eventCountRef, setEventLog]);
+}


### PR DESCRIPTION
- host sends document snapshot to gateway on connect
- gateway stores snapshot + buffers all ops afterwards, replays both to new joiners
- guest decodes snapshot, forks document with own client_id
- host re-sends fresh snapshot every 100 ops to keep buffer bounded
- snapshot wire encode/decode added to crdt-core