### PR TITLE
Implement authentication in client -> gateway communication

### DIFF
--- a/gateway/cmd/server/auth_filter.go
+++ b/gateway/cmd/server/auth_filter.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+func bearerAuthFilter(token string, next http.Handler) http.Handler {
+	expected := "Bearer " + token
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health", "/ws":
+			next.ServeHTTP(w, r)
+			return
+		}
+		if subtle.ConstantTimeCompare(
+			[]byte(r.Header.Get("Authorization")),
+			[]byte(expected),
+		) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/gateway/cmd/server/main.go
+++ b/gateway/cmd/server/main.go
@@ -17,6 +17,12 @@ import (
 
 func main() {
 	level := parseGatewayLogLevel(os.Getenv("GATEWAY_LOG_LEVEL"))
+	authToken := os.Getenv("GATEWAY_AUTH_TOKEN")
+	if authToken == "" {
+		slog.Error("GATEWAY_AUTH_TOKEN is not set; refusing to start")
+		os.Exit(1)
+	}
+
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: level,
 	}))
@@ -34,14 +40,21 @@ func main() {
 	h := hub.New()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/ws", h.HandleWS)
+	if rpm := parseWSRateLimitRPM(); rpm > 0 {
+		lim := newWSRateLimiter(rpm)
+		mux.Handle("/ws", wsRateLimitMiddleware(lim, h.HandleWS))
+		slog.Info("websocket rate limit enabled", "rpm", rpm)
+	} else {
+		mux.HandleFunc("/ws", h.HandleWS)
+		slog.Info("websocket rate limit disabled (GATEWAY_WS_RATE_LIMIT_RPM<=0)")
+	}
 	mux.HandleFunc("/rooms", h.HandleCreateRoom)
 	mux.HandleFunc("/end-session", h.HandleEndSession)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{Handler: bearerAuthFilter(authToken, mux)}
 	serveErr := make(chan error, 1)
 	go func() {
 		serveErr <- srv.Serve(ln)

--- a/gateway/cmd/server/ws_limit.go
+++ b/gateway/cmd/server/ws_limit.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/didip/tollbooth/v8"
+	"github.com/didip/tollbooth/v8/libstring"
+	"github.com/didip/tollbooth/v8/limiter"
+)
+
+func clientIPForWSRateLimit(r *http.Request) string {
+	if s := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); s != "" {
+		return libstring.CanonicalizeIP(s)
+	}
+	if s := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); s != "" {
+		parts := strings.Split(s, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		if len(parts) > 0 && parts[0] != "" {
+			return libstring.CanonicalizeIP(parts[0])
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return libstring.CanonicalizeIP(strings.TrimSpace(r.RemoteAddr))
+	}
+	return libstring.CanonicalizeIP(host)
+}
+
+func newWSRateLimiter(rpm int) *limiter.Limiter {
+	max := float64(rpm) / 60.0
+	return tollbooth.NewLimiter(max, nil)
+}
+
+func wsRateLimitMiddleware(lmt *limiter.Limiter, next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIPForWSRateLimit(r)
+		if ip == "" {
+			ip = "unknown"
+		}
+		keys := []string{ip, r.URL.Path}
+		if httpErr := tollbooth.LimitByKeys(lmt, keys); httpErr != nil {
+			slog.Warn("websocket rate limit exceeded", "remote_ip", ip, "path", r.URL.Path)
+			lmt.ExecOnLimitReached(w, r)
+			if lmt.GetOverrideDefaultResponseWriter() {
+				return
+			}
+			w.Header().Add("Content-Type", lmt.GetMessageContentType())
+			w.WriteHeader(httpErr.StatusCode)
+			_, _ = w.Write([]byte(httpErr.Message))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func parseWSRateLimitRPM() int {
+	raw := strings.TrimSpace(os.Getenv("GATEWAY_WS_RATE_LIMIT_RPM"))
+	if raw == "" {
+		return 5
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		slog.Warn("invalid GATEWAY_WS_RATE_LIMIT_RPM; using default", "value", raw, "default", 5)
+		return 5
+	}
+	return n
+}

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -2,4 +2,9 @@ module gateway
 
 go 1.25.10
 
-require github.com/coder/websocket v1.8.14
+require (
+	github.com/coder/websocket v1.8.14
+	github.com/didip/tollbooth/v8 v8.0.1
+)
+
+require github.com/go-pkgz/expirable-cache/v3 v3.0.0 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -1,2 +1,16 @@
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/didip/tollbooth/v8 v8.0.1 h1:VAAapTo1t4Bn6bbpcHjuovwoa9u3JH++wgjbpWv+rB8=
+github.com/didip/tollbooth/v8 v8.0.1/go.mod h1:oEd9l+ep373d7DmvKLc0a5gasPOev2mTewi6KPQBGJ4=
+github.com/go-pkgz/expirable-cache/v3 v3.0.0 h1:u3/gcu3sabLYiTCevoRKv+WzjIn5oo7P8XtiXBeRDLw=
+github.com/go-pkgz/expirable-cache/v3 v3.0.0/go.mod h1:2OQiDyEGQalYecLWmXprm3maPXeVb5/6/X7yRPYTzec=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -4,12 +4,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/coder/websocket"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
-
-	"github.com/coder/websocket"
 
 	"gateway/internal/client"
 	"gateway/internal/room"
@@ -17,6 +18,7 @@ import (
 )
 
 const stagingOpsBuffer = 64
+const maxRoomJoinRetries = 3
 
 type Hub struct {
 	mu    sync.Mutex
@@ -27,12 +29,12 @@ func New() *Hub {
 	return &Hub{rooms: make(map[string]*room.Room)}
 }
 
-func (h *Hub) newRoomID() string {
+func newRoomID() (string, error) {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		return "00000000"
+		return "", err
 	}
-	return hex.EncodeToString(b[:])
+	return hex.EncodeToString(b[:]), nil
 }
 
 func (h *Hub) HandleCreateRoom(w http.ResponseWriter, r *http.Request) {
@@ -41,7 +43,12 @@ func (h *Hub) HandleCreateRoom(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	id := h.newRoomID()
+	id, err := newRoomID()
+	if err != nil {
+		slog.Error("create room failed: could not read random bytes", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
 	slog.Info("room id generated", "room_id", id)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"room_id": id})
@@ -73,25 +80,40 @@ func (h *Hub) discardIfStale(id string, r *room.Room) {
 	}
 }
 
-func (h *Hub) register(c *client.Client) *room.Room {
-	for {
+func (h *Hub) register(c *client.Client) (*room.Room, error) {
+	for range maxRoomJoinRetries + 1 {
 		r := h.getOrCreateRoom(c.RoomID)
-		if r.Join(c) {
+		err := r.Join(c)
+		if err == nil {
 			slog.Info(
 				"client registered to room",
 				"room_id", c.RoomID,
 				"client_id", c.ID,
 				"size", r.Size(),
 			)
-			return r
+			return r, nil
 		}
-		slog.Warn(
-			"room join failed; retrying after stale room cleanup",
-			"room_id", c.RoomID,
-			"client_id", c.ID,
-		)
-		h.discardIfStale(c.RoomID, r)
+		if errors.Is(err, room.ErrDuplicateClientID) {
+			slog.Warn(
+				"duplicate client_id; rejecting websocket",
+				"room_id", c.RoomID,
+				"client_id", c.ID,
+			)
+			return nil, err
+		}
+		if errors.Is(err, room.ErrRoomClosed) {
+			slog.Warn(
+				"room join failed; retrying after stale room cleanup",
+				"room_id", c.RoomID,
+				"client_id", c.ID,
+			)
+			h.discardIfStale(c.RoomID, r)
+			continue
+		}
+		return nil, err
 	}
+	slog.Error("register failed: exceeded max retries", "room_id", c.RoomID, "client_id", c.ID)
+	return nil, fmt.Errorf("room %s unstable after %d attempts", c.RoomID, maxRoomJoinRetries)
 }
 
 func (h *Hub) unregister(c *client.Client, r *room.Room) {
@@ -196,7 +218,15 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 	slog.Info("websocket upgraded", "room_id", roomID, "client_id", clientID)
 
 	c := client.New(clientID, roomID, conn)
-	rm := h.register(c)
+	rm, err := h.register(c)
+	if err != nil {
+		if errors.Is(err, room.ErrDuplicateClientID) {
+			_ = conn.Close(websocket.StatusPolicyViolation, "duplicate client_id")
+		} else {
+			_ = conn.Close(websocket.StatusInternalError, "join failed")
+		}
+		return
+	}
 	slog.Info("client joined room", "room_id", roomID, "client_id", clientID, "size", rm.Size())
 	defer func() {
 		h.unregister(c, rm)

--- a/gateway/internal/hub/hub_test.go
+++ b/gateway/internal/hub/hub_test.go
@@ -60,6 +60,10 @@ func TestHub_PostRoomsReturnsFreshID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("POST /rooms: %v", err)
 		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			t.Fatalf("POST /rooms: status=%d, want 200", resp.StatusCode)
+		}
 		var body map[string]string
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			t.Fatalf("decode: %v", err)
@@ -67,7 +71,7 @@ func TestHub_PostRoomsReturnsFreshID(t *testing.T) {
 		resp.Body.Close()
 		id := body["room_id"]
 		if !regexp.MustCompile(`^[0-9a-f]{8}$`).MatchString(id) {
-			t.Fatalf("room_id=%q, want 8 hex chars", id)
+			t.Fatalf("room_id=%q, want 8 lowercase hex chars", id)
 		}
 		ids = append(ids, id)
 	}
@@ -118,6 +122,27 @@ func TestHub_TwoClientsSameRoomShareSet(t *testing.T) {
 	}
 	if rooms := h.Rooms(); len(rooms) != 1 || rooms[0] != "shared" {
 		t.Fatalf("Rooms=%v, want [shared]", rooms)
+	}
+}
+
+func TestHub_DuplicateClientIDRejected(t *testing.T) {
+	srv, _ := newTestServer(t)
+	first := dial(t, wsURL(srv.URL, "dup-room", "same-id"))
+	defer first.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	second, _, err := websocket.Dial(ctx, wsURL(srv.URL, "dup-room", "same-id"), nil)
+	if err != nil {
+		t.Fatalf("second dial: %v", err)
+	}
+	defer second.Close(websocket.StatusNormalClosure, "")
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), time.Second)
+	defer readCancel()
+	_, _, err = second.Read(readCtx)
+	if err == nil {
+		t.Fatal("expected read on duplicate client_id connection to fail after server closes it")
 	}
 }
 

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -1,11 +1,17 @@
 package room
 
 import (
+	"errors"
 	"log/slog"
 	"sync"
 
 	"gateway/internal/client"
 	"gateway/internal/wire"
+)
+
+var (
+	ErrRoomClosed        = errors.New("room closed")
+	ErrDuplicateClientID = errors.New("duplicate client_id")
 )
 
 const opsBufferSize = 256
@@ -38,16 +44,22 @@ func New(id string) *Room {
 	}
 }
 
-func (r *Room) Join(c *client.Client) bool {
+func (r *Room) Join(c *client.Client) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {
 		slog.Warn("join rejected: room already closed", "room_id", r.ID, "client_id", c.ID)
-		return false
+		return ErrRoomClosed
+	}
+	for existing := range r.clients {
+		if existing.ID == c.ID {
+			slog.Warn("join rejected: duplicate client_id", "room_id", r.ID, "client_id", c.ID)
+			return ErrDuplicateClientID
+		}
 	}
 	r.clients[c] = struct{}{}
 	slog.Info("join accepted", "room_id", r.ID, "client_id", c.ID, "size", len(r.clients))
-	return true
+	return nil
 }
 
 func (r *Room) Leave(c *client.Client, onEmpty func()) {

--- a/gateway/internal/room/room_test.go
+++ b/gateway/internal/room/room_test.go
@@ -1,6 +1,7 @@
 package room
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"sync"
@@ -21,8 +22,11 @@ func TestRoom_JoinLeaveTriggersOnEmpty(t *testing.T) {
 
 	a := client.New("a", "room-1", nil)
 	b := client.New("b", "room-1", nil)
-	if !r.Join(a) || !r.Join(b) {
-		t.Fatal("join rejected by fresh room")
+	if err := r.Join(a); err != nil {
+		t.Fatalf("join a: %v", err)
+	}
+	if err := r.Join(b); err != nil {
+		t.Fatalf("join b: %v", err)
 	}
 	if got := r.Size(); got != 2 {
 		t.Fatalf("Size=%d, want 2", got)
@@ -47,7 +51,9 @@ func TestRoom_SendToEmptyIsNoop(t *testing.T) {
 	go func() { r.Run(); close(runDone) }()
 
 	a := client.New("a", "room-2", nil)
-	r.Join(a)
+	if err := r.Join(a); err != nil {
+		t.Fatalf("join: %v", err)
+	}
 
 	r.Ops() <- BroadcastMsg{Sender: a, Data: []byte{0x00, 0xDE, 0xAD}}
 	r.Ops() <- BroadcastMsg{Sender: a, Data: []byte{}}
@@ -66,7 +72,9 @@ func TestRoom_DoubleLeaveIsSilent(t *testing.T) {
 	go func() { r.Run(); close(runDone) }()
 
 	a := client.New("a", "room-3", nil)
-	r.Join(a)
+	if err := r.Join(a); err != nil {
+		t.Fatalf("join: %v", err)
+	}
 
 	calls := 0
 	r.Leave(a, func() { calls++ })
@@ -88,12 +96,14 @@ func TestRoom_JoinAfterCloseIsRejected(t *testing.T) {
 	go func() { r.Run(); close(runDone) }()
 
 	a := client.New("a", "room-4", nil)
-	r.Join(a)
+	if err := r.Join(a); err != nil {
+		t.Fatalf("join: %v", err)
+	}
 	r.Leave(a, nil)
 
 	b := client.New("b", "room-4", nil)
-	if r.Join(b) {
-		t.Fatal("Join succeeded on closed room")
+	if err := r.Join(b); !errors.Is(err, ErrRoomClosed) {
+		t.Fatalf("Join on closed room: got %v, want ErrRoomClosed", err)
 	}
 
 	<-runDone
@@ -105,7 +115,9 @@ func TestRoom_SnapshotReplayToJoiner(t *testing.T) {
 	go func() { r.Run(); close(runDone) }()
 
 	host := client.New("host", "room-snap", nil)
-	r.Join(host)
+	if err := r.Join(host); err != nil {
+		t.Fatalf("join host: %v", err)
+	}
 
 	snapFrame := []byte{0x01, 0xAA, 0xBB}
 	r.Ops() <- BroadcastMsg{Sender: host, Data: snapFrame}
@@ -118,7 +130,9 @@ func TestRoom_SnapshotReplayToJoiner(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	joiner := client.New("joiner", "room-snap", nil)
-	r.Join(joiner)
+	if err := r.Join(joiner); err != nil {
+		t.Fatalf("join joiner: %v", err)
+	}
 
 	got := r.ReplayTo(joiner)
 	if !got {
@@ -147,5 +161,23 @@ done:
 
 	r.Leave(host, nil)
 	r.Leave(joiner, nil)
+	<-runDone
+}
+
+func TestRoom_DuplicateClientIDRejected(t *testing.T) {
+	r := New("room-dup")
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	a := client.New("same", "room-dup", nil)
+	b := client.New("same", "room-dup", nil)
+	if err := r.Join(a); err != nil {
+		t.Fatalf("first join: %v", err)
+	}
+	if err := r.Join(b); !errors.Is(err, ErrDuplicateClientID) {
+		t.Fatalf("second join: got %v, want ErrDuplicateClientID", err)
+	}
+
+	r.Leave(a, nil)
 	<-runDone
 }

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -4381,6 +4381,7 @@ version = "0.1.0"
 dependencies = [
  "crdt-core",
  "futures-util",
+ "hex",
  "local-ip-address",
  "log",
  "rand 0.8.6",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -35,3 +35,4 @@ futures-util = "0.3"
 toml = "0.8"
 reqwest = { version = "0.13.2", features = ["json"] }
 url = "2"
+hex = "0.4.3"

--- a/tauri-app/src-tauri/src/gateway/auth_token_generator.rs
+++ b/tauri-app/src-tauri/src/gateway/auth_token_generator.rs
@@ -1,0 +1,8 @@
+use rand::rngs::OsRng;
+use rand::RngCore;
+
+pub fn generate_gateway_token() -> String {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}

--- a/tauri-app/src-tauri/src/gateway/gateway_api.rs
+++ b/tauri-app/src-tauri/src/gateway/gateway_api.rs
@@ -2,11 +2,12 @@ use crate::gateway::types::{RoomResponse, GATEWAY_TIMEOUT};
 use log::{debug, warn};
 use url::Url;
 
-pub async fn create_room(port: u16) -> Result<String, String> {
+pub async fn create_room(port: u16, auth_token: &str) -> Result<String, String> {
     debug!("fetching gateway room id via /rooms: port={port}");
     tokio::time::timeout(GATEWAY_TIMEOUT, async {
         reqwest::Client::new()
             .post(format!("http://127.0.0.1:{port}/rooms"))
+            .bearer_auth(auth_token)
             .send()
             .await
             .map_err(|e| format!("gateway /rooms: {e}"))?
@@ -26,11 +27,12 @@ pub async fn create_room(port: u16) -> Result<String, String> {
     })?
 }
 
-pub async fn destroy_room(local_room_url: String) -> Result<(), String> {
+pub async fn destroy_room(local_room_url: String, auth_token: &str) -> Result<(), String> {
     let end_session_url = end_session_url_from_room_url(&local_room_url)?;
     tokio::time::timeout(GATEWAY_TIMEOUT, async {
         reqwest::Client::new()
             .post(&end_session_url)
+            .bearer_auth(auth_token)
             .send()
             .await
             .map_err(|e| {

--- a/tauri-app/src-tauri/src/gateway/mod.rs
+++ b/tauri-app/src-tauri/src/gateway/mod.rs
@@ -1,2 +1,3 @@
+pub mod auth_token_generator;
 pub mod gateway_api;
 mod types;

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -81,8 +81,13 @@ pub fn run() {
                     }
                 };
                 if let Some(url) = local_room_url {
-                    if let Err(e) = tauri::async_runtime::block_on(destroy_room(url)) {
-                        warn!("destroy_room on window close: {e}");
+                    match state.gateway_auth_token() {
+                        Some(ref t) => {
+                            if let Err(e) = tauri::async_runtime::block_on(destroy_room(url, t)) {
+                                warn!("destroy_room on window close: {e}");
+                            }
+                        }
+                        None => warn!("destroy_room on window close: gateway token missing"),
                     }
                 }
                 state.leave_session(&window.state::<WsState>());

--- a/tauri-app/src-tauri/src/processes/gateway_process.rs
+++ b/tauri-app/src-tauri/src/processes/gateway_process.rs
@@ -1,4 +1,5 @@
 use crate::app_config::config::AppConfig;
+use crate::gateway::auth_token_generator::generate_gateway_token;
 use crate::processes::types::{GatewayWorkflowResult, Sidecar, SidecarStatus};
 use crate::state::appstate::{AppRole, AppState};
 use log::{debug, info, warn};
@@ -10,11 +11,15 @@ pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult
     info!("gateway startup requested");
     let gateway_log_level = app.state::<AppConfig>().logging.gateway_level_for_env();
     debug!("gateway startup using log level: {}", gateway_log_level);
+
+    let gateway_token = generate_gateway_token();
+
     let (mut rx, child) = app
         .shell()
         .sidecar("peercode-gateway")
         .map_err(|e| format!("Gateway sidecar not found: {e}"))?
         .env("GATEWAY_LOG_LEVEL", gateway_log_level)
+        .env("GATEWAY_AUTH_TOKEN", gateway_token.clone())
         .spawn()
         .map_err(|e| format!("Failed to spawn gateway: {e}"))?;
 
@@ -28,11 +33,15 @@ pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult
             return Ok(None);
         }
         drop(role);
-        state.processes.lock().unwrap().gateway = Some(Sidecar {
-            proc: child,
-            name: "peercode-gateway".to_string(),
-            status: SidecarStatus::Enabled,
-        });
+        {
+            let mut procs = state.processes.lock().unwrap();
+            procs.gateway = Some(Sidecar {
+                proc: child,
+                name: "peercode-gateway".to_string(),
+                status: SidecarStatus::Enabled,
+            });
+            procs.gateway_auth_token = Some(gateway_token.clone());
+        }
         debug!("gateway process handle stored in app state");
     }
 
@@ -46,6 +55,7 @@ pub async fn run_gateway(app: &AppHandle) -> Result<Option<GatewayWorkflowResult
 
                     return Ok(Some(GatewayWorkflowResult {
                         lan_url: get_lan_url(port).await,
+                        gateway_auth_token: gateway_token,
                         port,
                         log_rx: rx,
                     }));

--- a/tauri-app/src-tauri/src/processes/process_coordinator.rs
+++ b/tauri-app/src-tauri/src/processes/process_coordinator.rs
@@ -71,5 +71,6 @@ pub async fn launch(app: AppHandle) -> Result<CombinedWorkflowResult, String> {
         port,
         lan_url,
         public_url,
+        gateway_auth_token: gateway.gateway_auth_token,
     })
 }

--- a/tauri-app/src-tauri/src/processes/types.rs
+++ b/tauri-app/src-tauri/src/processes/types.rs
@@ -14,6 +14,7 @@ pub struct Sidecar {
 }
 
 pub struct GatewayWorkflowResult {
+    pub gateway_auth_token: String,
     pub lan_url: Option<String>,
     pub port: u16,
     pub log_rx: Receiver<CommandEvent>,
@@ -28,6 +29,7 @@ pub struct CombinedWorkflowResult {
     pub port: u16,
     pub public_url: Option<String>,
     pub lan_url: Option<String>,
+    pub gateway_auth_token: String,
 }
 
 #[derive(serde::Serialize)]

--- a/tauri-app/src-tauri/src/session/host_commands.rs
+++ b/tauri-app/src-tauri/src/session/host_commands.rs
@@ -1,7 +1,7 @@
 use crate::gateway::gateway_api::{create_room, destroy_room};
 use crate::processes::process_coordinator;
 use crate::processes::types::SidecarStatus;
-use crate::session::session_types::{SessionReadyPayload, SESSION_READY};
+use crate::session::session_types::{HostSessionSetup, SessionReadyPayload, SESSION_READY};
 use crate::state::appstate::{AppRole, AppState};
 use crate::state::document::{request, DocOp};
 use crate::state::ws_state::WsState;
@@ -9,15 +9,6 @@ use crdt_core::encode_snapshot;
 use log::{debug, error, info, warn};
 use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Emitter, Manager, State};
-
-struct HostSessionSetup {
-    room_id: String,
-    port: u16,
-    lan_url: Option<String>,
-    public_url: Option<String>,
-    local_room_url: String,
-    public_room_url: Option<String>,
-}
 
 #[tauri::command]
 pub async fn host_session(app: AppHandle) -> Result<(), String> {
@@ -76,7 +67,11 @@ pub async fn end_session(state: State<'_, AppState>, ws: State<'_, WsState>) -> 
             }
         }
     };
-    destroy_room(local_room_url).await?;
+    let gateway_auth_token = state
+        .gateway_auth_token()
+        .ok_or_else(|| "Gateway auth token missing for running gateway process".to_string())?;
+
+    destroy_room(local_room_url, &gateway_auth_token).await?;
     state.leave_session(&ws);
     let previous_role = {
         let mut role = state.role.lock().unwrap();
@@ -116,7 +111,7 @@ fn ensure_gateway_spawn_allowed(app: &AppHandle) -> Result<(), String> {
 async fn prepare_host_session(app: &AppHandle) -> Result<HostSessionSetup, String> {
     info!("start_host_session launching gateway/tunnel workflow");
     let workflow = process_coordinator::launch(app.clone()).await?;
-    let room_id = create_room(workflow.port).await?;
+    let room_id = create_room(workflow.port, &workflow.gateway_auth_token).await?;
     let local_room_url = format!("ws://127.0.0.1:{}/ws?room={}", workflow.port, room_id);
     let public_url = workflow.public_url;
     let public_room_url = public_url

--- a/tauri-app/src-tauri/src/session/session_types.rs
+++ b/tauri-app/src-tauri/src/session/session_types.rs
@@ -35,3 +35,12 @@ pub struct JoinInfo {
     pub server_url: String,
     pub room_id: String,
 }
+
+pub struct HostSessionSetup {
+    pub room_id: String,
+    pub port: u16,
+    pub lan_url: Option<String>,
+    pub public_url: Option<String>,
+    pub local_room_url: String,
+    pub public_room_url: Option<String>,
+}

--- a/tauri-app/src-tauri/src/state/appstate.rs
+++ b/tauri-app/src-tauri/src/state/appstate.rs
@@ -50,6 +50,7 @@ impl AppRole {
 pub struct HostProcesses {
     pub gateway: Option<Sidecar>,
     pub tunnel: Option<Sidecar>,
+    pub gateway_auth_token: Option<String>,
 }
 
 impl AppState {
@@ -60,6 +61,7 @@ impl AppState {
             processes: Mutex::new(HostProcesses {
                 gateway: None,
                 tunnel: None,
+                gateway_auth_token: None,
             }),
             current_document_name: Mutex::new(None),
             ops_since_snapshot: AtomicU32::new(0),
@@ -72,10 +74,19 @@ impl AppState {
         ws.disconnect_nowait();
     }
 
+    /// Bearer token for authenticated requests to the local gateway sidecar (`GATEWAY_AUTH_TOKEN`).
+    pub fn gateway_auth_token(&self) -> Option<String> {
+        self.processes.lock().unwrap().gateway_auth_token.clone()
+    }
+
     pub fn kill_host_processes(&self) {
         let mut procs = self.processes.lock().unwrap();
         self.kill_proc(procs.tunnel.take());
+        let had_gateway = procs.gateway.is_some();
         self.kill_proc(procs.gateway.take());
+        if had_gateway {
+            procs.gateway_auth_token = None;
+        }
     }
 
     fn kill_proc(&self, proc: Option<Sidecar>) {


### PR DESCRIPTION
  * Added a secure token generation that is passed to the gateway as an env. var. at startup
  * added a filter to the gateway that invalidates any http request that doesnt contain the token in a header
  * modified gateway api to send the token on every http call
  * added a check in gateway to prevent peers with matching client_id from joining the server to prevent brute forcing
  * made room_id-s longer to prevent brute force attacks
  * Added rate limiting to websocket connection to avoid brute force attacks