### PR TITLE
Fix  non-crdtl bugs 

### DIFF
--- a/gateway/cmd/server/ws_limit.go
+++ b/gateway/cmd/server/ws_limit.go
@@ -35,7 +35,9 @@ func clientIPForWSRateLimit(r *http.Request) string {
 
 func newWSRateLimiter(rpm int) *limiter.Limiter {
 	max := float64(rpm) / 60.0
-	return tollbooth.NewLimiter(max, nil)
+	lmt := tollbooth.NewLimiter(max, nil)
+	lmt.SetBurst(10)
+	return lmt
 }
 
 func wsRateLimitMiddleware(lmt *limiter.Limiter, next http.HandlerFunc) http.Handler {

--- a/gateway/internal/client/client.go
+++ b/gateway/internal/client/client.go
@@ -77,7 +77,11 @@ func (c *Client) ReadPump(ctx context.Context, ops chan<- []byte, leave chan<- *
 	for {
 		_, data, err := c.conn.Read(ctx)
 		if err != nil {
-			slog.Debug("read pump stopped", "room_id", c.RoomID, "client_id", c.ID, "error", err)
+			slog.Warn("read pump: connection read error; closing",
+				"room_id", c.RoomID,
+				"client_id", c.ID,
+				"error", err,
+			)
 			return
 		}
 		select {
@@ -106,7 +110,12 @@ func (c *Client) WritePump(ctx context.Context) {
 				return
 			}
 			if err := c.conn.Write(ctx, websocket.MessageBinary, msg); err != nil {
-				slog.Debug("write pump stopped", "room_id", c.RoomID, "client_id", c.ID, "error", err)
+				slog.Warn("write pump: connection write error; closing",
+					"room_id", c.RoomID,
+					"client_id", c.ID,
+					"frame_bytes", len(msg),
+					"error", err,
+				)
 				return
 			}
 			slog.Debug("write pump sent frame", "room_id", c.RoomID, "client_id", c.ID, "bytes", len(msg))

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -20,6 +20,12 @@ import (
 const stagingOpsBuffer = 64
 const maxRoomJoinRetries = 3
 
+// maxInboundMessageBytes caps the size of a single incoming WebSocket frame.
+// The coder/websocket default is 32 KiB which is easily exceeded by a large
+// paste or full-document snapshot. 64 MiB is far above any realistic payload
+// while still preventing unbounded memory growth from a malicious sender.
+const maxInboundMessageBytes = 64 * 1024 * 1024
+
 type Hub struct {
 	mu    sync.Mutex
 	rooms map[string]*room.Room
@@ -215,6 +221,7 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("websocket upgrade failed", "room_id", roomID, "error", err)
 		return
 	}
+	conn.SetReadLimit(maxInboundMessageBytes)
 	slog.Info("websocket upgraded", "room_id", roomID, "client_id", clientID)
 
 	c := client.New(clientID, roomID, conn)

--- a/tauri-app/src-tauri/src/session/joint_commands.rs
+++ b/tauri-app/src-tauri/src/session/joint_commands.rs
@@ -50,6 +50,15 @@ pub fn get_session_info(state: State<'_, AppState>) -> SessionInfo {
 pub fn leave_session(state: State<'_, AppState>, ws: State<'_, WsState>) -> Result<(), String> {
     info!("leave session requested");
     state.leave_session(&ws);
+    {
+        let mut role = state.role.lock().unwrap();
+        let prev = role.clone();
+        *role = AppRole::Undecided;
+        info!(
+            "leave_session: role reset to idle from status={}",
+            prev.status()
+        );
+    }
     info!("leave session completed");
     Ok(())
 }

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -191,14 +191,22 @@ function installPlainTextPasteHandler(
   if (!domNode) return;
 
   const handlePaste = (event: ClipboardEvent) => {
-    const text = event.clipboardData?.getData("text/plain") ?? "";
     event.preventDefault();
     event.stopPropagation();
 
-    if (!text) return;
+    const text = event.clipboardData?.getData("text/plain") ?? "";
 
-    editorInstance.focus();
-    editorInstance.trigger("plain-text-paste", "type", { text });
+    if (text) {
+      editorInstance.focus();
+      editorInstance.trigger("plain-text-paste", "type", { text });
+      return;
+    }
+
+    void navigator.clipboard.readText().then((clipText) => {
+      if (!clipText) return;
+      editorInstance.focus();
+      editorInstance.trigger("plain-text-paste", "type", { text: clipText });
+    });
   };
 
   domNode.addEventListener("paste", handlePaste, { capture: true });
@@ -383,11 +391,22 @@ function AppContent({ username }: AppContentProps) {
       public_url: string | null;
       local_room_url: string | null;
       public_room_url: string | null;
+      room_id: string | null;
     }>("get_session_info").then((info) => {
       setSessionStatus(info.status);
-      if (info.local_room_url ?? info.lan_url) {
-        setLanUrl(info.local_room_url ?? info.lan_url);
+
+      if (info.lan_url && !info.room_id) {
+        throw new Error(
+          "get_session_info: lan_url present but room_id is null",
+        );
       }
+
+      const lanRoomUrl =
+        info.lan_url && info.room_id
+          ? `${info.lan_url}?room=${info.room_id}`
+          : null;
+
+      if (lanRoomUrl) setLanUrl(lanRoomUrl);
       if (info.public_room_url ?? info.public_url) {
         setPublicUrl(info.public_room_url ?? info.public_url);
       }
@@ -409,7 +428,11 @@ function AppContent({ username }: AppContentProps) {
           room_id: string;
         }>("session://session-ready", (e) => {
           setSessionStatus("host");
-          setLanUrl(e.payload.local_room_url);
+          setLanUrl(
+            e.payload.lan_url
+              ? `${e.payload.lan_url}?room=${e.payload.room_id}`
+              : e.payload.local_room_url,
+          );
           setPublicUrl(e.payload.public_room_url);
           setProcessesRunning({
             gateway: "Enabled",


### PR DESCRIPTION
 * fixed a bug that left client in a stale state after leaving a session as a guest
 * Fixed frontend to display local network URL instead of local machine URL which caused lan joining to not work
 * Increased ip rate limiting burst size to allow multiple people joining the session from same wifi network without IP rate limiter flagging them
 * Fixed the bug where text that was copied from another window or app wasnt pasted
 * raised the websocket frame limit in go gateway to 64 mib so connections don't break when copy pasting large text
 * added better log messages for websocket connection closing 