### PR TITLE
14 optimize block retrieval by text position

### DIFF
--- a/.claude/rules/crdt-core-position-index.md
+++ b/.claude/rules/crdt-core-position-index.md
@@ -1,0 +1,29 @@
+---
+description: B+ tree position index internals for the crdt-core CRDT
+globs:
+  - crdt-core/**
+alwaysApply: false
+---
+
+# crdt-core position index
+
+`crdt-core/src/index/` is an augmented B+ tree that gives O(log n) conversion
+between a `BlockId` and its visible-text character position. It is a *secondary,
+derived* structure layered over the CRDT linked list (the linked list, traversed
+via `block.right()`, remains the source of truth for order).
+
+Key facts before touching `index/` or any `Document` mutation:
+
+- The index must move in lockstep with the linked list. Every mutation that
+  changes block order, length, or visibility mirrors itself into `position_index`
+  (`insert_after`, `split_entry`, `set_deleted`, `rebuild_from_order`).
+- In debug builds, `assert_index_matches_linked_list` (`document/debug.rs`) and
+  `index/validate.rs` panic on any drift. These are `#[cfg(debug_assertions)]`.
+- Module split: `index/structs/` is data + constructors only; sibling files
+  (`mutate`, `find`, `split`, `propagate`, `descend`, `build`, `storage_ops`)
+  hold operations. Branching factors in `index/constants.rs` differ between
+  debug (tiny, forces splits in tests) and release (wide).
+
+Full walkthrough with diagrams and a file-by-file guide:
+
+@../../docs/b-tree-optimisation.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,15 @@ The CRDT `Document` is **not** behind a mutex — it lives inside a single Tokio
 
 The actor emits events to the webview when state changes: `crdt://remote-change`, `crdt://snapshot-applied`, `crdt://document-reset` (constants in `types.rs`). The frontend's `remoteChangeListener.ts` / `snapshotListener.ts` apply these to Monaco without re-broadcasting (the `isApplyingRemote` ref gates the `onDidChangeModelContent` handler in `App.tsx`).
 
+### Position index (`crdt-core/src/index/`)
+
+The CRDT linked list of blocks (traversed via `block.right()`) is the **source of truth for order**, but walking it to convert between a `BlockId` and its visible-text character position is O(n). `Document` therefore carries a `PositionIndex` — an augmented B+ tree that aggregates each subtree's `visible_len`, giving O(log n) `position_of(id)` and `find_at_position(pos)`. It is a *secondary, derived* structure: it must be mutated in lockstep with the linked list, never independently.
+
+- Every `Document` mutation that changes block order, length, or visibility mirrors itself into the index (`insert_after`, `split_entry`, `set_deleted`, `rebuild_from_order`) — see the call sites in `document/integrate.rs` and `Document::restore` in `document.rs`.
+- **Debug oracle:** in debug builds `assert_index_matches_linked_list` (`document/debug.rs`) walks the list after each mutation and panics if the tree disagrees; `index/validate.rs` separately checks the tree's internal invariants. These are `#[cfg(debug_assertions)]` only.
+- Module shape (SOLID split): `index/structs/` holds data + constructors only (`Storage`, `Leaf`, `Node`, `PositionIndex`, …); the sibling files hold operations (`mutate`, `find`, `split`, `propagate`, `descend`, `build`, `storage_ops`). Branching factors live in `index/constants.rs` and **differ between debug (tiny, to force splits in tests) and release (wide)** — a behavioral knob, not a constant.
+- Full walkthrough with diagrams: `docs/b-tree-optimisation.md`.
+
 ### Wire protocol — two parallel surfaces
 
 There is a binary wire framing **and** a JSON protocol envelope. They are not the same layer:
@@ -116,3 +125,4 @@ When the host window is destroyed (see `on_window_event` in `lib.rs`), `destroy_
 - **Edition 2024 / Rust stable** for `crdt-core`; **edition 2021** for `tauri-app/src-tauri`. Go module pins **`go 1.25.10`**.
 - The `peercode.config.toml` next to `Cargo.toml` is embedded into the binary via `include_str!` at compile time — config changes require a rebuild, not just a restart.
 - When you change `WireBlock`, `OpMessage`, `DeleteSet`, or `Snapshot` encoding in `crdt-core`, also update the matching constants/tests in `gateway/internal/wire/` and re-run the `protocol_drift` tests on both sides.
+- When you add a `Document` mutation that changes block order, length, or visibility, mirror it into `position_index` in the same step and let the debug oracle (`assert_index_matches_linked_list`) catch any drift — never let the index and linked list diverge.

--- a/crdt-core/src/document.rs
+++ b/crdt-core/src/document.rs
@@ -1,3 +1,4 @@
+use crate::index::PositionIndex;
 use crate::store::{DeleteSet, StateVector, StructStore};
 use crate::structs::Block;
 use crate::types::{BlockId, ClientId};
@@ -22,6 +23,7 @@ pub struct Document {
     pub delete_set: DeleteSet,
     pub seen_delete_set: DeleteSet,
     pub head: Option<BlockId>,
+    pub position_index: PositionIndex,
     pending_blocks: Vec<Block>,
     pending_delete_sets: Vec<DeleteSet>,
 }
@@ -35,6 +37,7 @@ impl Document {
             delete_set: DeleteSet::new(),
             seen_delete_set: DeleteSet::new(),
             head: None,
+            position_index: PositionIndex::new(),
             pending_blocks: Vec::new(),
             pending_delete_sets: Vec::new(),
         }
@@ -51,6 +54,20 @@ impl Document {
         pending_blocks: Vec<Block>,
         pending_delete_sets: Vec<DeleteSet>,
     ) -> Self {
+        let mut position_index = PositionIndex::new();
+        let mut entries: Vec<(BlockId, u64, bool)> = Vec::new();
+        let mut curr = head;
+        while let Some(id) = curr {
+            match store.get(&id) {
+                Some(block) => {
+                    entries.push((id, block.len, block.is_deleted));
+                    curr = block.right();
+                }
+                None => break,
+            }
+        }
+        position_index.rebuild_from_order(entries.into_iter());
+
         Document {
             client_id,
             store,
@@ -58,6 +75,7 @@ impl Document {
             delete_set,
             seen_delete_set,
             head,
+            position_index,
             pending_blocks,
             pending_delete_sets,
         }

--- a/crdt-core/src/document.rs
+++ b/crdt-core/src/document.rs
@@ -3,6 +3,8 @@ use crate::store::{DeleteSet, StateVector, StructStore};
 use crate::structs::Block;
 use crate::types::{BlockId, ClientId};
 
+#[cfg(debug_assertions)]
+mod debug;
 mod integrate;
 mod ops;
 mod pending;
@@ -23,7 +25,7 @@ pub struct Document {
     pub delete_set: DeleteSet,
     pub seen_delete_set: DeleteSet,
     pub head: Option<BlockId>,
-    pub position_index: PositionIndex,
+    pub(crate) position_index: PositionIndex,
     pending_blocks: Vec<Block>,
     pending_delete_sets: Vec<DeleteSet>,
 }

--- a/crdt-core/src/document/debug.rs
+++ b/crdt-core/src/document/debug.rs
@@ -1,0 +1,90 @@
+use super::Document;
+use log::trace;
+
+impl Document {
+    pub(super) fn assert_index_matches_linked_list(&self) {
+        let mut pos = 0u64;
+        let mut curr = self.head;
+
+        let max_steps = self.store.total_blocks().saturating_add(1);
+        let mut steps: usize = 0;
+
+        while let Some(id) = curr {
+            steps += 1;
+            debug_assert!(
+                steps <= max_steps,
+                "cycle detected in document linked list at block {id:?}"
+            );
+
+            let block = self
+                .store
+                .get(&id)
+                .expect("linked-list points to block missing from store");
+            let tree_pos = self.position_index.position_of(id);
+            assert_eq!(
+                tree_pos,
+                Some(pos),
+                "position_of({:?}) = {:?}, linked-list position = {}",
+                id,
+                tree_pos,
+                pos,
+            );
+            if !block.is_deleted {
+                pos += block.len;
+            }
+            curr = block.right();
+        }
+
+        let tree_total = self.position_index.visible_len();
+        assert_eq!(
+            tree_total, pos,
+            "position_index.visible_len() = {}, linked-list visible total = {}",
+            tree_total, pos,
+        );
+
+        self.position_index
+            .debug_validate()
+            .expect("position index invariants must hold");
+    }
+
+    pub fn debug_linked_list(&self) -> String {
+        trace!("fetching document linked list visualization");
+        let mut parts = Vec::new();
+        let mut curr = self.head;
+        let max_steps = self.store.total_blocks().saturating_add(1);
+        let mut steps: usize = 0;
+
+        while let Some(id) = curr {
+            steps += 1;
+            debug_assert!(
+                steps <= max_steps,
+                "cycle detected in document linked list at block {id:?}"
+            );
+
+            if let Some(block) = self.store.get(&id) {
+                let content = if block.content().is_empty() {
+                    "<empty>".to_string()
+                } else {
+                    block.content().replace('\n', "\\n")
+                };
+
+                if block.is_deleted {
+                    parts.push(format!("[DEL:{content}]"));
+                } else {
+                    parts.push(content);
+                }
+
+                curr = block.right();
+            } else {
+                parts.push("<broken-link>".to_string());
+                break;
+            }
+        }
+
+        if parts.is_empty() {
+            "<empty>".to_string()
+        } else {
+            parts.join(" --- ")
+        }
+    }
+}

--- a/crdt-core/src/document/integrate.rs
+++ b/crdt-core/src/document/integrate.rs
@@ -115,6 +115,7 @@ impl Document {
     /// Insert `block` into the store and link it.
     pub(super) fn integrate(&mut self, block: Block) -> Result<BlockId, DocumentError> {
         let block_id = block.id;
+        let block_len = block.len;
         debug!(
             "integrate start: id={:?}, origin_left={:?}, origin_right={:?}, len={}",
             block_id, block.origin_left, block.origin_right, block.len
@@ -131,12 +132,40 @@ impl Document {
         };
         self.store.insert(block);
         self.link_block(block_id, final_left, final_right)?;
+        let tree_left = match final_left {
+            Some(l_id) => self.store.get(&l_id).map(|b| b.id),
+            None => None,
+        };
+        self.position_index
+            .insert_after(tree_left, block_id, block_len);
         debug!(
             "integrate outcome: block {:?} inserted with neighbors left={:?}, right={:?}",
             block_id, final_left, final_right
         );
 
+        #[cfg(debug_assertions)]
+        self.assert_index_matches_linked_list();
+
         Ok(block_id)
+    }
+
+    pub(super) fn mark_block_deleted(
+        &mut self,
+        id: &BlockId,
+    ) -> Result<(u64, Option<BlockId>), DocumentError> {
+        let (len, right) = {
+            let block = self
+                .store
+                .mark_deleted(id)
+                .ok_or(DocumentError::BlockNotFound(*id))?;
+            (block.len, block.right())
+        };
+        self.position_index.set_deleted(*id);
+
+        #[cfg(debug_assertions)]
+        self.assert_index_matches_linked_list();
+
+        Ok((len, right))
     }
 
     /// Split `block_id` at `offset`. Returns the id of the newly created
@@ -193,10 +222,17 @@ impl Document {
                 .set_left(Some(new_block_id));
         }
 
+        self.position_index
+            .split_entry(block_id, offset, new_block_id);
+
         debug!(
             "split outcome: {:?} split at offset {} creating {:?}",
             block_id, offset, new_block_id
         );
+
+        #[cfg(debug_assertions)]
+        self.assert_index_matches_linked_list();
+
         Ok(Some(new_block_id))
     }
 

--- a/crdt-core/src/document/ops.rs
+++ b/crdt-core/src/document/ops.rs
@@ -149,13 +149,7 @@ impl Document {
                 self.split_block(current_id, remaining)?;
             }
 
-            let (deleted_len, next_id) = {
-                let block = self
-                    .store
-                    .mark_deleted(&current_id)
-                    .ok_or(DocumentError::BlockNotFound(current_id))?;
-                (block.len, block.right())
-            };
+            let (deleted_len, next_id) = self.mark_block_deleted(&current_id)?;
 
             self.delete_set.add(current_id, deleted_len);
             diff.add(current_id, deleted_len);

--- a/crdt-core/src/document/pending.rs
+++ b/crdt-core/src/document/pending.rs
@@ -167,11 +167,7 @@ impl Document {
                     None
                 };
 
-                let actual_len = self
-                    .store
-                    .mark_deleted(&block_id)
-                    .ok_or(DocumentError::BlockNotFound(block_id))?
-                    .len;
+                let (actual_len, _) = self.mark_block_deleted(&block_id)?;
 
                 if let Some(position) = position_before {
                     changes.push(RemoteChange::Delete {

--- a/crdt-core/src/document/tests/mod.rs
+++ b/crdt-core/src/document/tests/mod.rs
@@ -4,6 +4,8 @@ use crate::structs::Block;
 use crate::types::{BlockId, ClientId, Clock};
 use crate::wire::WireBlock;
 
+mod sync_invariant;
+
 fn block_id(client: u64, clock: u64) -> BlockId {
     BlockId::new(ClientId::new(client), Clock::new(clock))
 }
@@ -12,9 +14,11 @@ fn doc_with_single_block(content: &str) -> (Document, BlockId) {
     let client_id = ClientId::new(1);
     let id = BlockId::new(client_id, Clock::new(0));
     let mut doc = Document::new(client_id);
+    let block = Block::new(id, None, None, content.to_string());
+    let len = block.len;
     doc.head = Some(id);
-    doc.store
-        .insert(Block::new(id, None, None, content.to_string()));
+    doc.store.insert(block);
+    doc.position_index.insert_after(None, id, len);
     (doc, id)
 }
 
@@ -29,9 +33,15 @@ fn doc_with_two_blocks(left: &str, right: &str) -> (Document, BlockId, BlockId) 
     let mut right_block = Block::new(right_id, Some(left_id), None, right.to_string());
     right_block.set_left(Some(left_id));
 
+    let left_len = left_block.len;
+    let right_len = right_block.len;
+
     doc.head = Some(left_id);
     doc.store.insert(left_block);
     doc.store.insert(right_block);
+    doc.position_index.insert_after(None, left_id, left_len);
+    doc.position_index
+        .insert_after(Some(left_id), right_id, right_len);
 
     (doc, left_id, right_id)
 }
@@ -160,7 +170,7 @@ fn split_block_updates_existing_right_neighbor() {
 #[test]
 fn split_deleted_block_keeps_both_halves_deleted() {
     let (mut doc, id) = doc_with_single_block("hello");
-    doc.store.get_mut(&id).unwrap().is_deleted = true;
+    doc.mark_block_deleted(&id).unwrap();
 
     doc.split_block(id, 2).unwrap();
 
@@ -214,9 +224,15 @@ fn get_block_and_offset_by_position_uses_character_offsets_for_unicode() {
     let mut right = Block::new(right_id, Some(left_id), None, "b".to_string());
     right.set_left(Some(left_id));
 
+    let left_len = left.len;
+    let right_len = right.len;
+
     doc.head = Some(left_id);
     doc.store.insert(left);
     doc.store.insert(right);
+    doc.position_index.insert_after(None, left_id, left_len);
+    doc.position_index
+        .insert_after(Some(left_id), right_id, right_len);
 
     let (found, offset, _tail) = doc.get_block_and_offset_by_position(2);
 
@@ -281,9 +297,14 @@ fn split_block_right_half_inherits_origin_right_not_current_right() {
     c.set_left(Some(a_id));
     a.set_right(Some(c_id));
 
+    let a_len = a.len;
+    let c_len = c.len;
+
     doc.head = Some(a_id);
     doc.store.insert(a);
     doc.store.insert(c);
+    doc.position_index.insert_after(None, a_id, a_len);
+    doc.position_index.insert_after(Some(a_id), c_id, c_len);
 
     doc.split_block(a_id, 1).unwrap();
 

--- a/crdt-core/src/document/tests/sync_invariant.rs
+++ b/crdt-core/src/document/tests/sync_invariant.rs
@@ -1,0 +1,258 @@
+use crate::document::Document;
+use crate::store::DeleteSet;
+use crate::structs::Block;
+use crate::types::ClientId;
+use crate::wire::WireBlock;
+
+struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng { state: seed }
+    }
+    fn next(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.state
+    }
+    fn range(&mut self, max: u64) -> u64 {
+        if max == 0 { 0 } else { self.next() % max }
+    }
+}
+
+const ALPHABET: &[char] = &['a', 'b', 'c', 'd', 'e', ' ', '\n'];
+
+fn random_string(rng: &mut Rng) -> String {
+    let len = (rng.range(4) + 1) as usize;
+    (0..len)
+        .map(|_| ALPHABET[(rng.next() % ALPHABET.len() as u64) as usize])
+        .collect()
+}
+
+fn local_insert(doc: &mut Document, rng: &mut Rng, outbox: &mut Vec<WireBlock>) {
+    let visible = doc.position_index.visible_len();
+    let pos = rng.range(visible + 1);
+    let content = random_string(rng);
+    if let Some(wire) = doc.local_insert(pos, &content).unwrap() {
+        outbox.push(wire);
+    }
+}
+
+fn local_delete(doc: &mut Document, rng: &mut Rng, outbox: &mut Vec<DeleteSet>) {
+    let visible = doc.position_index.visible_len();
+    if visible == 0 {
+        return;
+    }
+    let pos = rng.range(visible);
+    let max_len = (visible - pos).min(4);
+    let len = rng.range(max_len) + 1;
+    let ds = doc.delete(pos, len).unwrap();
+    if !ds.is_empty() {
+        outbox.push(ds);
+    }
+}
+
+fn sync(src_blocks: &mut Vec<WireBlock>, src_ds: &mut Vec<DeleteSet>, dst: &mut Document) {
+    for wire in src_blocks.drain(..) {
+        dst.remote_insert(Block::from(wire)).unwrap();
+    }
+    for ds in src_ds.drain(..) {
+        dst.apply_delete_set(&ds).unwrap();
+    }
+}
+
+#[test]
+fn insert_at_end_of_first_line_goes_on_line_one() {
+    let mut doc = Document::new(ClientId::new(1));
+    doc.local_insert(0, "line1\nline2").unwrap();
+    assert_eq!(doc.get_text(), "line1\nline2");
+    doc.local_insert(5, "X").unwrap();
+    assert_eq!(
+        doc.get_text(),
+        "line1X\nline2",
+        "typing at end-of-line-1 must stay on line 1"
+    );
+}
+
+#[test]
+fn insert_at_end_of_first_line_then_propagate_to_guest() {
+    let mut host = Document::new(ClientId::new(1));
+    let mut guest = Document::new(ClientId::new(2));
+
+    let w0 = host.local_insert(0, "line1\nline2").unwrap().expect("wire");
+    guest.remote_insert(Block::from(w0)).unwrap();
+    assert_eq!(guest.get_text(), "line1\nline2");
+
+    let w1 = guest.local_insert(5, "X").unwrap().expect("wire");
+    assert_eq!(guest.get_text(), "line1X\nline2");
+
+    host.remote_insert(Block::from(w1)).unwrap();
+    assert_eq!(host.get_text(), "line1X\nline2");
+}
+
+#[test]
+fn type_char_by_char_then_insert_at_end_of_first_line() {
+    let mut doc = Document::new(ClientId::new(1));
+    let text = "line1\nline2";
+    for (i, c) in text.chars().enumerate() {
+        doc.local_insert(i as u64, &c.to_string()).unwrap();
+    }
+    assert_eq!(doc.get_text(), "line1\nline2");
+
+    doc.local_insert(5, "X").unwrap();
+    assert_eq!(doc.get_text(), "line1X\nline2");
+}
+
+#[test]
+fn type_char_by_char_then_insert_multiple_on_first_line() {
+    let mut doc = Document::new(ClientId::new(1));
+    let text = "line1\nline2";
+    for (i, c) in text.chars().enumerate() {
+        doc.local_insert(i as u64, &c.to_string()).unwrap();
+    }
+    let extra = " more";
+    for (i, c) in extra.chars().enumerate() {
+        doc.local_insert(5 + i as u64, &c.to_string()).unwrap();
+    }
+    assert_eq!(doc.get_text(), "line1 more\nline2");
+}
+
+#[test]
+fn guest_types_on_first_line_after_remote_two_lines() {
+    let mut host = Document::new(ClientId::new(1));
+    let mut guest = Document::new(ClientId::new(2));
+
+    let text = "line1\nline2";
+    let mut wires: Vec<WireBlock> = Vec::new();
+    for (i, c) in text.chars().enumerate() {
+        let w = host
+            .local_insert(i as u64, &c.to_string())
+            .unwrap()
+            .expect("wire");
+        wires.push(w);
+    }
+    for w in wires {
+        guest.remote_insert(Block::from(w)).unwrap();
+    }
+    assert_eq!(guest.get_text(), "line1\nline2");
+
+    let extra = " more";
+    let mut guest_wires: Vec<WireBlock> = Vec::new();
+    for (i, c) in extra.chars().enumerate() {
+        let w = guest
+            .local_insert(5 + i as u64, &c.to_string())
+            .unwrap()
+            .expect("wire");
+        guest_wires.push(w);
+    }
+    assert_eq!(guest.get_text(), "line1 more\nline2");
+
+    for w in guest_wires {
+        host.remote_insert(Block::from(w)).unwrap();
+    }
+    assert_eq!(host.get_text(), "line1 more\nline2");
+}
+
+#[test]
+fn type_on_first_line_after_snapshot_load() {
+    let mut host = Document::new(ClientId::new(1));
+    let text = "line1\nline2";
+    for (i, c) in text.chars().enumerate() {
+        host.local_insert(i as u64, &c.to_string()).unwrap();
+    }
+    assert_eq!(host.get_text(), text);
+
+    let mut joiner = host.fork(ClientId::new(2));
+    assert_eq!(joiner.get_text(), text);
+
+    for (i, c) in " more".chars().enumerate() {
+        joiner.local_insert(5 + i as u64, &c.to_string()).unwrap();
+    }
+    assert_eq!(joiner.get_text(), "line1 more\nline2");
+}
+
+#[test]
+fn type_in_middle_of_first_line_after_snapshot_load() {
+    let mut host = Document::new(ClientId::new(1));
+    let text = "line1\nline2";
+    for (i, c) in text.chars().enumerate() {
+        host.local_insert(i as u64, &c.to_string()).unwrap();
+    }
+    let mut joiner = host.fork(ClientId::new(2));
+    joiner.local_insert(2, "X").unwrap();
+    assert_eq!(joiner.get_text(), "liXne1\nline2");
+    joiner.local_insert(3, "Y").unwrap();
+    assert_eq!(joiner.get_text(), "liXYne1\nline2");
+}
+
+#[test]
+fn host_typing_chars_one_by_one_guest_text_matches() {
+    let mut host = Document::new(ClientId::new(1));
+    let mut guest = Document::new(ClientId::new(2));
+
+    let text = "I don't think position rendering is working lol";
+    let mut wires = Vec::new();
+    for (i, c) in text.chars().enumerate() {
+        let wire = host
+            .local_insert(i as u64, &c.to_string())
+            .unwrap()
+            .expect("insert produces a wire");
+        wires.push(wire);
+    }
+
+    let mut received_positions = Vec::new();
+    for wire in wires {
+        let changes = guest.remote_insert(Block::from(wire)).unwrap();
+        for c in &changes {
+            if let crate::document::RemoteChange::Insert { position, content } = c {
+                received_positions.push((*position, content.clone()));
+            }
+        }
+    }
+
+    println!("Host text: {:?}", host.get_text());
+    println!("Guest text: {:?}", guest.get_text());
+    if guest.get_text() != text {
+        println!("Positions reported to frontend: {:?}", received_positions);
+    }
+    assert_eq!(host.get_text(), text, "host should have the text");
+    assert_eq!(guest.get_text(), text, "guest must match host");
+}
+
+#[test]
+fn sync_invariant_holds_under_random_ops() {
+    let mut doc_a = Document::new(ClientId::new(1));
+    let mut doc_b = Document::new(ClientId::new(2));
+
+    let mut a_to_b_blocks: Vec<WireBlock> = Vec::new();
+    let mut b_to_a_blocks: Vec<WireBlock> = Vec::new();
+    let mut a_to_b_ds: Vec<DeleteSet> = Vec::new();
+    let mut b_to_a_ds: Vec<DeleteSet> = Vec::new();
+
+    let mut rng = Rng::new(0xDEAD_BEEF_CAFE_BABE);
+
+    for _ in 0..200 {
+        match rng.range(10) {
+            0..=2 => local_insert(&mut doc_a, &mut rng, &mut a_to_b_blocks),
+            3..=5 => local_insert(&mut doc_b, &mut rng, &mut b_to_a_blocks),
+            6 => local_delete(&mut doc_a, &mut rng, &mut a_to_b_ds),
+            7 => local_delete(&mut doc_b, &mut rng, &mut b_to_a_ds),
+            8 => sync(&mut a_to_b_blocks, &mut a_to_b_ds, &mut doc_b),
+            9 => sync(&mut b_to_a_blocks, &mut b_to_a_ds, &mut doc_a),
+            _ => unreachable!(),
+        }
+
+        doc_a.assert_index_matches_linked_list();
+        doc_b.assert_index_matches_linked_list();
+    }
+
+    sync(&mut a_to_b_blocks, &mut a_to_b_ds, &mut doc_b);
+    sync(&mut b_to_a_blocks, &mut b_to_a_ds, &mut doc_a);
+
+    doc_a.assert_index_matches_linked_list();
+    doc_b.assert_index_matches_linked_list();
+}

--- a/crdt-core/src/document/traversal.rs
+++ b/crdt-core/src/document/traversal.rs
@@ -126,9 +126,17 @@ impl Document {
     /// Visible-text character position of the block identified by `target`.
     /// Backed by the position index: O(log n) instead of an O(n) linked-list walk.
     pub(super) fn visible_position_of(&self, target: BlockId) -> u64 {
-        self.position_index
+        let t0 = std::time::Instant::now();
+        let result = self
+            .position_index
             .position_of(target)
-            .unwrap_or_else(|| self.position_index.visible_len())
+            .unwrap_or_else(|| self.position_index.visible_len());
+        debug!(
+            "visible_position_of: {}µs  doc_blocks={}",
+            t0.elapsed().as_micros(),
+            self.store.total_blocks(),
+        );
+        result
     }
 
     /// Locate the block and intra-block offset that corresponds to a visible
@@ -138,8 +146,13 @@ impl Document {
         &self,
         position: u64,
     ) -> (Option<BlockId>, u64, Option<BlockId>) {
-        debug!("get_block_and_offset_by_position({:?})", position);
+        let t0 = std::time::Instant::now();
         let r = self.position_index.find_at_position(position);
+        debug!(
+            "get_block_and_offset_by_position: {}µs  doc_blocks={}",
+            t0.elapsed().as_micros(),
+            self.store.total_blocks(),
+        );
         (r.id, r.offset, r.tail_id)
     }
 }

--- a/crdt-core/src/document/traversal.rs
+++ b/crdt-core/src/document/traversal.rs
@@ -1,6 +1,6 @@
 use super::Document;
 use crate::types::BlockId;
-use log::{debug, trace};
+use log::trace;
 
 impl Document {
     pub fn get_text(&self) -> String {
@@ -35,108 +35,12 @@ impl Document {
         text
     }
 
-    #[cfg(debug_assertions)]
-    pub(super) fn assert_index_matches_linked_list(&self) {
-        let mut pos = 0u64;
-        let mut curr = self.head;
-
-        let max_steps = self.store.total_blocks().saturating_add(1);
-        let mut steps: usize = 0;
-
-        while let Some(id) = curr {
-            steps += 1;
-            debug_assert!(
-                steps <= max_steps,
-                "cycle detected in document linked list at block {id:?}"
-            );
-
-            let block = self
-                .store
-                .get(&id)
-                .expect("linked-list points to block missing from store");
-            let tree_pos = self.position_index.position_of(id);
-            assert_eq!(
-                tree_pos,
-                Some(pos),
-                "position_of({:?}) = {:?}, linked-list position = {}",
-                id,
-                tree_pos,
-                pos,
-            );
-            if !block.is_deleted {
-                pos += block.len;
-            }
-            curr = block.right();
-        }
-
-        let tree_total = self.position_index.visible_len();
-        assert_eq!(
-            tree_total, pos,
-            "position_index.visible_len() = {}, linked-list visible total = {}",
-            tree_total, pos,
-        );
-
-        self.position_index
-            .debug_validate()
-            .expect("position index invariants must hold");
-    }
-
-    #[cfg(debug_assertions)]
-    pub fn debug_linked_list(&self) -> String {
-        trace!("fetching document linked list visualization");
-        let mut parts = Vec::new();
-        let mut curr = self.head;
-        let max_steps = self.store.total_blocks().saturating_add(1);
-        let mut steps: usize = 0;
-
-        while let Some(id) = curr {
-            steps += 1;
-            debug_assert!(
-                steps <= max_steps,
-                "cycle detected in document linked list at block {id:?}"
-            );
-
-            if let Some(block) = self.store.get(&id) {
-                let content = if block.content().is_empty() {
-                    "<empty>".to_string()
-                } else {
-                    block.content().replace('\n', "\\n")
-                };
-
-                if block.is_deleted {
-                    parts.push(format!("[DEL:{content}]"));
-                } else {
-                    parts.push(content);
-                }
-
-                curr = block.right();
-            } else {
-                parts.push("<broken-link>".to_string());
-                break;
-            }
-        }
-
-        if parts.is_empty() {
-            "<empty>".to_string()
-        } else {
-            parts.join(" --- ")
-        }
-    }
-
     /// Visible-text character position of the block identified by `target`.
     /// Backed by the position index: O(log n) instead of an O(n) linked-list walk.
     pub(super) fn visible_position_of(&self, target: BlockId) -> u64 {
-        let t0 = std::time::Instant::now();
-        let result = self
-            .position_index
+        self.position_index
             .position_of(target)
-            .unwrap_or_else(|| self.position_index.visible_len());
-        debug!(
-            "visible_position_of: {}µs  doc_blocks={}",
-            t0.elapsed().as_micros(),
-            self.store.total_blocks(),
-        );
-        result
+            .unwrap_or_else(|| self.position_index.visible_len())
     }
 
     /// Locate the block and intra-block offset that corresponds to a visible
@@ -146,13 +50,7 @@ impl Document {
         &self,
         position: u64,
     ) -> (Option<BlockId>, u64, Option<BlockId>) {
-        let t0 = std::time::Instant::now();
         let r = self.position_index.find_at_position(position);
-        debug!(
-            "get_block_and_offset_by_position: {}µs  doc_blocks={}",
-            t0.elapsed().as_micros(),
-            self.store.total_blocks(),
-        );
         (r.id, r.offset, r.tail_id)
     }
 }

--- a/crdt-core/src/document/traversal.rs
+++ b/crdt-core/src/document/traversal.rs
@@ -36,6 +36,52 @@ impl Document {
     }
 
     #[cfg(debug_assertions)]
+    pub(super) fn assert_index_matches_linked_list(&self) {
+        let mut pos = 0u64;
+        let mut curr = self.head;
+
+        let max_steps = self.store.total_blocks().saturating_add(1);
+        let mut steps: usize = 0;
+
+        while let Some(id) = curr {
+            steps += 1;
+            debug_assert!(
+                steps <= max_steps,
+                "cycle detected in document linked list at block {id:?}"
+            );
+
+            let block = self
+                .store
+                .get(&id)
+                .expect("linked-list points to block missing from store");
+            let tree_pos = self.position_index.position_of(id);
+            assert_eq!(
+                tree_pos,
+                Some(pos),
+                "position_of({:?}) = {:?}, linked-list position = {}",
+                id,
+                tree_pos,
+                pos,
+            );
+            if !block.is_deleted {
+                pos += block.len;
+            }
+            curr = block.right();
+        }
+
+        let tree_total = self.position_index.visible_len();
+        assert_eq!(
+            tree_total, pos,
+            "position_index.visible_len() = {}, linked-list visible total = {}",
+            tree_total, pos,
+        );
+
+        self.position_index
+            .debug_validate()
+            .expect("position index invariants must hold");
+    }
+
+    #[cfg(debug_assertions)]
     pub fn debug_linked_list(&self) -> String {
         trace!("fetching document linked list visualization");
         let mut parts = Vec::new();
@@ -77,57 +123,23 @@ impl Document {
         }
     }
 
-    /// Visible-text character position of the block identified by `target`
+    /// Visible-text character position of the block identified by `target`.
+    /// Backed by the position index: O(log n) instead of an O(n) linked-list walk.
     pub(super) fn visible_position_of(&self, target: BlockId) -> u64 {
-        let mut pos = 0u64;
-        let mut curr = self.head;
-        while let Some(id) = curr {
-            if id == target {
-                return pos;
-            }
-            let Some(block) = self.store.get(&id) else {
-                break;
-            };
-            if !block.is_deleted {
-                pos += block.len;
-            }
-            curr = block.right();
-        }
-        pos
+        self.position_index
+            .position_of(target)
+            .unwrap_or_else(|| self.position_index.visible_len())
     }
 
     /// Locate the block and intra-block offset that corresponds to a visible
     /// character position. Returns `(block_id, offset_within_block, tail_id)`.
+    /// Backed by the position index: O(log n) instead of O(n).
     pub(super) fn get_block_and_offset_by_position(
         &self,
-        mut position: u64,
+        position: u64,
     ) -> (Option<BlockId>, u64, Option<BlockId>) {
         debug!("get_block_and_offset_by_position({:?})", position);
-
-        let mut current_block = self.head.and_then(|id| self.store.get(&id));
-        let mut tail_id = None;
-
-        while let Some(block) = current_block {
-            tail_id = Some(block.id);
-
-            if block.is_deleted {
-                current_block = block.right().and_then(|id| self.store.get(&id));
-                continue;
-            }
-            let content_len = block.len;
-
-            if position < content_len {
-                debug!("position: {}, content_len: {}", position, content_len);
-                return (Some(block.id), position, None);
-            }
-            position -= content_len;
-            current_block = block.right().and_then(|id| self.store.get(&id));
-        }
-
-        debug!(
-            "get_block_and_offset_by_position({:?}) returned a tail block",
-            position
-        );
-        (None, position, tail_id)
+        let r = self.position_index.find_at_position(position);
+        (r.id, r.offset, r.tail_id)
     }
 }

--- a/crdt-core/src/index/build.rs
+++ b/crdt-core/src/index/build.rs
@@ -1,0 +1,53 @@
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::index::structs::node::{ChildSlot, Node};
+use crate::index::structs::storage::Storage;
+
+impl Storage {
+    pub fn make_root_node_for_two_leaves(
+        &mut self,
+        left: LeafIdx,
+        left_visible: u64,
+        right: LeafIdx,
+        right_visible: u64,
+    ) -> NodeIdx {
+        let mut node = Node::new(true);
+        node.child_slots[0] = Some(ChildSlot {
+            idx: left.0,
+            visible_len: left_visible,
+        });
+        node.child_slots[1] = Some(ChildSlot {
+            idx: right.0,
+            visible_len: right_visible,
+        });
+        node.num_children = 2;
+        let node_idx = NodeIdx(self.nodes.len() as u32);
+        self.nodes.push(node);
+        self.leaves[left.0 as usize].parent = Some(node_idx);
+        self.leaves[right.0 as usize].parent = Some(node_idx);
+        node_idx
+    }
+
+    pub fn make_root_node_for_two_nodes(
+        &mut self,
+        left: NodeIdx,
+        left_visible: u64,
+        right: NodeIdx,
+        right_visible: u64,
+    ) -> NodeIdx {
+        let mut node = Node::new(false);
+        node.child_slots[0] = Some(ChildSlot {
+            idx: left.0,
+            visible_len: left_visible,
+        });
+        node.child_slots[1] = Some(ChildSlot {
+            idx: right.0,
+            visible_len: right_visible,
+        });
+        node.num_children = 2;
+        let node_idx = NodeIdx(self.nodes.len() as u32);
+        self.nodes.push(node);
+        self.nodes[left.0 as usize].parent = Some(node_idx);
+        self.nodes[right.0 as usize].parent = Some(node_idx);
+        node_idx
+    }
+}

--- a/crdt-core/src/index/build.rs
+++ b/crdt-core/src/index/build.rs
@@ -1,5 +1,5 @@
 use crate::index::structs::handles::{LeafIdx, NodeIdx};
-use crate::index::structs::node::{ChildSlot, Node};
+use crate::index::structs::node::{ChildSlot, ChildType, Node};
 use crate::index::structs::storage::Storage;
 
 impl Storage {
@@ -10,18 +10,13 @@ impl Storage {
         right: LeafIdx,
         right_visible: u64,
     ) -> NodeIdx {
-        let mut node = Node::new(true);
-        node.child_slots[0] = Some(ChildSlot {
-            idx: left.0,
-            visible_len: left_visible,
-        });
-        node.child_slots[1] = Some(ChildSlot {
-            idx: right.0,
-            visible_len: right_visible,
-        });
-        node.num_children = 2;
-        let node_idx = NodeIdx(self.nodes.len() as u32);
-        self.nodes.push(node);
+        let node_idx = self.push_node_with_two_children(
+            ChildType::Leaf,
+            left.0,
+            left_visible,
+            right.0,
+            right_visible,
+        );
         self.leaves[left.0 as usize].parent = Some(node_idx);
         self.leaves[right.0 as usize].parent = Some(node_idx);
         node_idx
@@ -34,20 +29,38 @@ impl Storage {
         right: NodeIdx,
         right_visible: u64,
     ) -> NodeIdx {
-        let mut node = Node::new(false);
+        let node_idx = self.push_node_with_two_children(
+            ChildType::Node,
+            left.0,
+            left_visible,
+            right.0,
+            right_visible,
+        );
+        self.nodes[left.0 as usize].parent = Some(node_idx);
+        self.nodes[right.0 as usize].parent = Some(node_idx);
+        node_idx
+    }
+
+    fn push_node_with_two_children(
+        &mut self,
+        child_type: ChildType,
+        left_idx: u32,
+        left_visible: u64,
+        right_idx: u32,
+        right_visible: u64,
+    ) -> NodeIdx {
+        let mut node = Node::new(child_type);
         node.child_slots[0] = Some(ChildSlot {
-            idx: left.0,
+            idx: left_idx,
             visible_len: left_visible,
         });
         node.child_slots[1] = Some(ChildSlot {
-            idx: right.0,
+            idx: right_idx,
             visible_len: right_visible,
         });
         node.num_children = 2;
         let node_idx = NodeIdx(self.nodes.len() as u32);
         self.nodes.push(node);
-        self.nodes[left.0 as usize].parent = Some(node_idx);
-        self.nodes[right.0 as usize].parent = Some(node_idx);
         node_idx
     }
 }

--- a/crdt-core/src/index/constants.rs
+++ b/crdt-core/src/index/constants.rs
@@ -1,0 +1,9 @@
+#[cfg(not(debug_assertions))]
+pub(super) const LEAF_CHILDREN: usize = 32;
+#[cfg(not(debug_assertions))]
+pub(super) const NODE_CHILDREN: usize = 16;
+
+#[cfg(debug_assertions)]
+pub(super) const LEAF_CHILDREN: usize = 4;
+#[cfg(debug_assertions)]
+pub(super) const NODE_CHILDREN: usize = 4;

--- a/crdt-core/src/index/constants.rs
+++ b/crdt-core/src/index/constants.rs
@@ -1,7 +1,7 @@
 #[cfg(not(debug_assertions))]
-pub(super) const LEAF_CHILDREN: usize = 32;
+pub(super) const LEAF_CHILDREN: usize = 64;
 #[cfg(not(debug_assertions))]
-pub(super) const NODE_CHILDREN: usize = 16;
+pub(super) const NODE_CHILDREN: usize = 32;
 
 #[cfg(debug_assertions)]
 pub(super) const LEAF_CHILDREN: usize = 4;

--- a/crdt-core/src/index/descend.rs
+++ b/crdt-core/src/index/descend.rs
@@ -1,0 +1,58 @@
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::index::structs::storage::Storage;
+
+impl Storage {
+    pub fn descend_leftmost_leaf(&self, start: NodeIdx) -> LeafIdx {
+        let mut current = start;
+        loop {
+            let node = &self.nodes[current.0 as usize];
+            debug_assert!(node.num_children > 0);
+            let first = node.child_slots[0].expect("at least one child");
+            if node.is_leaf_parent {
+                return LeafIdx(first.idx);
+            } else {
+                current = NodeIdx(first.idx);
+            }
+        }
+    }
+
+    pub fn bubble_visible_len_delta(&mut self, leaf_idx: LeafIdx, delta: i64) {
+        let mut parent_opt = self.leaves[leaf_idx.0 as usize].parent;
+        let mut child_idx_u32 = leaf_idx.0;
+
+        while let Some(parent) = parent_opt {
+            let node = &mut self.nodes[parent.0 as usize];
+            let mut found = false;
+            for slot in node.child_slots.iter_mut() {
+                if let Some(s) = slot.as_mut()
+                    && s.idx == child_idx_u32
+                {
+                    s.visible_len = (s.visible_len as i64 + delta) as u64;
+                    found = true;
+                    break;
+                }
+            }
+            debug_assert!(found, "parent slot pointing to child not found");
+            parent_opt = node.parent;
+            child_idx_u32 = parent.0;
+        }
+    }
+
+    pub fn bubble_visible_len_delta_from_node(&mut self, node_idx: NodeIdx, delta: i64) {
+        let mut parent_opt = self.nodes[node_idx.0 as usize].parent;
+        let mut child_idx_u32 = node_idx.0;
+        while let Some(parent) = parent_opt {
+            let node = &mut self.nodes[parent.0 as usize];
+            for slot in node.child_slots.iter_mut() {
+                if let Some(s) = slot.as_mut()
+                    && s.idx == child_idx_u32
+                {
+                    s.visible_len = (s.visible_len as i64 + delta) as u64;
+                    break;
+                }
+            }
+            parent_opt = node.parent;
+            child_idx_u32 = parent.0;
+        }
+    }
+}

--- a/crdt-core/src/index/descend.rs
+++ b/crdt-core/src/index/descend.rs
@@ -8,7 +8,7 @@ impl Storage {
             let node = &self.nodes[current.0 as usize];
             debug_assert!(node.num_children > 0);
             let first = node.child_slots[0].expect("at least one child");
-            if node.is_leaf_parent {
+            if node.is_leaf_parent() {
                 return LeafIdx(first.idx);
             } else {
                 current = NodeIdx(first.idx);
@@ -17,42 +17,33 @@ impl Storage {
     }
 
     pub fn bubble_visible_len_delta(&mut self, leaf_idx: LeafIdx, delta: i64) {
-        let mut parent_opt = self.leaves[leaf_idx.0 as usize].parent;
-        let mut child_idx_u32 = leaf_idx.0;
-
-        while let Some(parent) = parent_opt {
-            let node = &mut self.nodes[parent.0 as usize];
-            let mut found = false;
-            for slot in node.child_slots.iter_mut() {
-                if let Some(s) = slot.as_mut()
-                    && s.idx == child_idx_u32
-                {
-                    s.visible_len = (s.visible_len as i64 + delta) as u64;
-                    found = true;
-                    break;
-                }
-            }
-            debug_assert!(found, "parent slot pointing to child not found");
-            parent_opt = node.parent;
-            child_idx_u32 = parent.0;
-        }
+        let parent = self.leaves[leaf_idx.0 as usize].parent;
+        self.bubble_visible_len_delta_from_child(parent, leaf_idx.0, delta);
     }
 
     pub fn bubble_visible_len_delta_from_node(&mut self, node_idx: NodeIdx, delta: i64) {
-        let mut parent_opt = self.nodes[node_idx.0 as usize].parent;
-        let mut child_idx_u32 = node_idx.0;
+        let parent = self.nodes[node_idx.0 as usize].parent;
+        self.bubble_visible_len_delta_from_child(parent, node_idx.0, delta);
+    }
+
+    fn bubble_visible_len_delta_from_child(
+        &mut self,
+        mut parent_opt: Option<NodeIdx>,
+        mut child_idx: u32,
+        delta: i64,
+    ) {
         while let Some(parent) = parent_opt {
             let node = &mut self.nodes[parent.0 as usize];
-            for slot in node.child_slots.iter_mut() {
-                if let Some(s) = slot.as_mut()
-                    && s.idx == child_idx_u32
-                {
-                    s.visible_len = (s.visible_len as i64 + delta) as u64;
-                    break;
-                }
-            }
+            let slot = node
+                .child_slots
+                .iter_mut()
+                .take(node.num_children as usize)
+                .flatten()
+                .find(|s| s.idx == child_idx)
+                .expect("parent slot pointing to child not found");
+            slot.visible_len = (slot.visible_len as i64 + delta) as u64;
             parent_opt = node.parent;
-            child_idx_u32 = parent.0;
+            child_idx = parent.0;
         }
     }
 }

--- a/crdt-core/src/index/find.rs
+++ b/crdt-core/src/index/find.rs
@@ -1,0 +1,137 @@
+use crate::index::structs::find_result::FindResult;
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::index::structs::position_index::PositionIndex;
+use crate::index::structs::root::Root;
+use crate::types::BlockId;
+
+impl PositionIndex {
+    pub fn visible_len(&self) -> u64 {
+        match self.storage.root {
+            Root::Empty => 0,
+            Root::Leaf(idx) => self.storage.leaves[idx.0 as usize].visible_len(),
+            Root::Node(idx) => self.storage.nodes[idx.0 as usize].visible_len(),
+        }
+    }
+
+    pub fn position_of(&self, id: BlockId) -> Option<u64> {
+        let (leaf_idx, slot): (LeafIdx, u8) = *self.storage.id_to_leaf.get(&id)?;
+        let pos_within = self.sum_visible_before_slot(leaf_idx, slot);
+        Some(pos_within + self.sum_visible_left_of_subtree(leaf_idx))
+    }
+
+    pub fn find_at_position(&self, mut pos: u64) -> FindResult {
+        let total = self.visible_len();
+        if pos >= total {
+            return FindResult {
+                id: None,
+                offset: pos - total,
+                tail_id: self.rightmost_entry_id(),
+            };
+        }
+        let leaf_idx = self.descend_to_leaf_at_pos(&mut pos);
+        self.scan_leaf_for_pos(leaf_idx, pos)
+    }
+
+    fn sum_visible_before_slot(&self, leaf_idx: LeafIdx, slot: u8) -> u64 {
+        let leaf = &self.storage.leaves[leaf_idx.0 as usize];
+        let mut pos = 0u64;
+        for s in 0..slot as usize {
+            if let Some(e) = &leaf.entries[s] {
+                pos += e.visible_len();
+            }
+        }
+        pos
+    }
+
+    fn sum_visible_left_of_subtree(&self, leaf_idx: LeafIdx) -> u64 {
+        let mut pos = 0u64;
+        let mut child_idx_u32 = leaf_idx.0;
+        let mut parent_opt = self.storage.leaves[leaf_idx.0 as usize].parent;
+        while let Some(parent) = parent_opt {
+            let node = &self.storage.nodes[parent.0 as usize];
+            for slot in node.child_slots.iter() {
+                match slot {
+                    Some(s) if s.idx == child_idx_u32 => break,
+                    Some(s) => pos += s.visible_len,
+                    None => break,
+                }
+            }
+            child_idx_u32 = parent.0;
+            parent_opt = node.parent;
+        }
+        pos
+    }
+
+    fn descend_to_leaf_at_pos(&self, pos: &mut u64) -> LeafIdx {
+        let mut current = match self.storage.root {
+            Root::Empty => unreachable!("caller guarantees pos < total"),
+            Root::Leaf(l) => return l,
+            Root::Node(n) => n,
+        };
+        loop {
+            let node = &self.storage.nodes[current.0 as usize];
+            let mut chosen: u32 = u32::MAX;
+            for slot in node.child_slots.iter().take(node.num_children as usize) {
+                let s = slot.expect("populated slot");
+                if *pos < s.visible_len {
+                    chosen = s.idx;
+                    break;
+                }
+                *pos -= s.visible_len;
+            }
+            debug_assert_ne!(
+                chosen,
+                u32::MAX,
+                "pos < total but no child matched (augmentation drift?)"
+            );
+            if node.is_leaf_parent {
+                return LeafIdx(chosen);
+            }
+            current = NodeIdx(chosen);
+        }
+    }
+
+    fn scan_leaf_for_pos(&self, leaf_idx: LeafIdx, mut pos: u64) -> FindResult {
+        let leaf = &self.storage.leaves[leaf_idx.0 as usize];
+        for slot in 0..leaf.num_entries as usize {
+            let e = leaf.entries[slot].expect("populated entry");
+            if e.is_deleted {
+                continue;
+            }
+            if pos < e.len {
+                return FindResult {
+                    id: Some(e.id),
+                    offset: pos,
+                    tail_id: None,
+                };
+            }
+            pos -= e.len;
+        }
+        unreachable!("pos < total but the chosen leaf didn't contain it");
+    }
+
+    fn rightmost_entry_id(&self) -> Option<BlockId> {
+        let leaf_idx = self.descend_rightmost_leaf()?;
+        let leaf = &self.storage.leaves[leaf_idx.0 as usize];
+        (0..leaf.num_entries as usize)
+            .rev()
+            .find_map(|slot| leaf.entries[slot].map(|e| e.id))
+    }
+
+    fn descend_rightmost_leaf(&self) -> Option<LeafIdx> {
+        let mut current = match self.storage.root {
+            Root::Empty => return None,
+            Root::Leaf(l) => return Some(l),
+            Root::Node(n) => n,
+        };
+        loop {
+            let node = &self.storage.nodes[current.0 as usize];
+            let last = (node.num_children - 1) as usize;
+            let last_idx = node.child_slots[last].expect("populated").idx;
+            if node.is_leaf_parent {
+                return Some(LeafIdx(last_idx));
+            }
+            current = NodeIdx(last_idx);
+        }
+    }
+}

--- a/crdt-core/src/index/find.rs
+++ b/crdt-core/src/index/find.rs
@@ -84,7 +84,7 @@ impl PositionIndex {
                 u32::MAX,
                 "pos < total but no child matched (augmentation drift?)"
             );
-            if node.is_leaf_parent {
+            if node.is_leaf_parent() {
                 return LeafIdx(chosen);
             }
             current = NodeIdx(chosen);
@@ -128,7 +128,7 @@ impl PositionIndex {
             let node = &self.storage.nodes[current.0 as usize];
             let last = (node.num_children - 1) as usize;
             let last_idx = node.child_slots[last].expect("populated").idx;
-            if node.is_leaf_parent {
+            if node.is_leaf_parent() {
                 return Some(LeafIdx(last_idx));
             }
             current = NodeIdx(last_idx);

--- a/crdt-core/src/index/mod.rs
+++ b/crdt-core/src/index/mod.rs
@@ -1,0 +1,19 @@
+mod constants;
+mod structs;
+
+mod build;
+mod descend;
+mod find;
+mod mutate;
+mod propagate;
+mod split;
+mod storage_ops;
+
+#[cfg(debug_assertions)]
+mod validate;
+
+#[cfg(test)]
+mod tests;
+
+pub use structs::find_result::FindResult;
+pub use structs::position_index::PositionIndex;

--- a/crdt-core/src/index/mutate.rs
+++ b/crdt-core/src/index/mutate.rs
@@ -1,0 +1,176 @@
+use crate::index::constants::LEAF_CHILDREN;
+use crate::index::structs::handles::LeafIdx;
+use crate::index::structs::leaf::LeafEntry;
+use crate::index::structs::position_index::PositionIndex;
+use crate::index::structs::root::Root;
+use crate::index::structs::storage::Storage;
+use crate::types::BlockId;
+
+enum InsertTarget {
+    DoneEmpty,
+    At {
+        leaf_idx: LeafIdx,
+        after_slot: Option<u8>,
+    },
+}
+
+impl PositionIndex {
+    pub fn insert_after(&mut self, prev: Option<BlockId>, id: BlockId, len: u64) {
+        let entry = LeafEntry {
+            id,
+            len,
+            is_deleted: false,
+        };
+
+        let (leaf_idx, after_slot) = match self.resolve_insert_target(prev, entry) {
+            InsertTarget::DoneEmpty => return,
+            InsertTarget::At {
+                leaf_idx,
+                after_slot,
+            } => (leaf_idx, after_slot),
+        };
+
+        let leaf = &self.storage.leaves[leaf_idx.0 as usize];
+        if (leaf.num_entries as usize) < LEAF_CHILDREN {
+            self.storage.insert_into_leaf(leaf_idx, after_slot, entry);
+            self.storage.bubble_visible_len_delta(leaf_idx, len as i64);
+            return;
+        }
+
+        let (right_idx, left_visible, right_visible) =
+            self.storage.split_leaf(leaf_idx, after_slot, entry);
+        self.attach_after_leaf_split(leaf_idx, left_visible, right_idx, right_visible);
+    }
+
+    pub fn split_entry(&mut self, id: BlockId, offset: u64, new_id: BlockId) {
+        let (leaf_idx, slot) = self.storage.locate(id);
+        let new_entry = self.shrink_left_half_for_split(leaf_idx, slot, offset, new_id);
+
+        let leaf_has_room =
+            (self.storage.leaves[leaf_idx.0 as usize].num_entries as usize) < LEAF_CHILDREN;
+        if leaf_has_room {
+            self.storage
+                .insert_into_leaf(leaf_idx, Some(slot), new_entry);
+            return;
+        }
+
+        let (right_idx, left_visible, right_visible) =
+            self.storage.split_leaf(leaf_idx, Some(slot), new_entry);
+        self.storage
+            .propagate_leaf_split(leaf_idx, left_visible, right_idx, right_visible);
+    }
+
+    pub fn set_deleted(&mut self, id: BlockId) {
+        let (leaf_idx, slot) = self.storage.locate(id);
+        let leaf = &mut self.storage.leaves[leaf_idx.0 as usize];
+        let entry = leaf.entries[slot as usize]
+            .as_mut()
+            .expect("located entry must exist");
+        if entry.is_deleted {
+            return;
+        }
+        let delta = -(entry.len as i64);
+        entry.is_deleted = true;
+        self.storage.bubble_visible_len_delta(leaf_idx, delta);
+    }
+
+    pub fn rebuild_from_order(&mut self, entries: impl Iterator<Item = (BlockId, u64, bool)>) {
+        self.storage = Storage::new();
+        let mut prev: Option<BlockId> = None;
+        for (id, len, is_deleted) in entries {
+            self.insert_after(prev, id, len);
+            if is_deleted {
+                self.set_deleted(id);
+            }
+            prev = Some(id);
+        }
+    }
+
+    fn resolve_insert_target(&mut self, prev: Option<BlockId>, entry: LeafEntry) -> InsertTarget {
+        match self.storage.root {
+            Root::Empty => {
+                assert!(
+                    prev.is_none(),
+                    "cannot insert after a block in an empty tree"
+                );
+                self.storage.push_first_entry(entry);
+                InsertTarget::DoneEmpty
+            }
+            Root::Leaf(idx) => {
+                let after_slot = prev.map(|p| {
+                    let (l, slot) = self.storage.locate(p);
+                    debug_assert_eq!(l, idx);
+                    slot
+                });
+                InsertTarget::At {
+                    leaf_idx: idx,
+                    after_slot,
+                }
+            }
+            Root::Node(root_idx) => match prev {
+                Some(p) => {
+                    let (l, slot) = self.storage.locate(p);
+                    InsertTarget::At {
+                        leaf_idx: l,
+                        after_slot: Some(slot),
+                    }
+                }
+                None => {
+                    let leftmost = self.storage.descend_leftmost_leaf(root_idx);
+                    InsertTarget::At {
+                        leaf_idx: leftmost,
+                        after_slot: None,
+                    }
+                }
+            },
+        }
+    }
+
+    fn attach_after_leaf_split(
+        &mut self,
+        left_idx: LeafIdx,
+        left_visible: u64,
+        right_idx: LeafIdx,
+        right_visible: u64,
+    ) {
+        if matches!(self.storage.root, Root::Leaf(_)) {
+            let node_idx = self.storage.make_root_node_for_two_leaves(
+                left_idx,
+                left_visible,
+                right_idx,
+                right_visible,
+            );
+            self.storage.root = Root::Node(node_idx);
+            return;
+        }
+        self.storage
+            .propagate_leaf_split(left_idx, left_visible, right_idx, right_visible);
+    }
+
+    fn shrink_left_half_for_split(
+        &mut self,
+        leaf_idx: LeafIdx,
+        slot: u8,
+        offset: u64,
+        new_id: BlockId,
+    ) -> LeafEntry {
+        let leaf = &mut self.storage.leaves[leaf_idx.0 as usize];
+        let entry = leaf.entries[slot as usize]
+            .as_mut()
+            .expect("located entry must exist");
+        assert!(
+            offset > 0 && offset < entry.len,
+            "split offset {} out of range for entry len {}",
+            offset,
+            entry.len
+        );
+        let was_deleted = entry.is_deleted;
+        let original_len = entry.len;
+        entry.len = offset;
+        LeafEntry {
+            id: new_id,
+            len: original_len - offset,
+            is_deleted: was_deleted,
+        }
+    }
+}

--- a/crdt-core/src/index/mutate.rs
+++ b/crdt-core/src/index/mutate.rs
@@ -16,6 +16,10 @@ enum InsertTarget {
 
 impl PositionIndex {
     pub fn insert_after(&mut self, prev: Option<BlockId>, id: BlockId, len: u64) {
+        debug_assert!(
+            !self.storage.id_to_leaf.contains_key(&id),
+            "insert_after called with id {id:?} already present in index"
+        );
         let entry = LeafEntry {
             id,
             len,
@@ -43,6 +47,10 @@ impl PositionIndex {
     }
 
     pub fn split_entry(&mut self, id: BlockId, offset: u64, new_id: BlockId) {
+        debug_assert!(
+            !self.storage.id_to_leaf.contains_key(&new_id),
+            "split_entry called with new_id {new_id:?} already present in index"
+        );
         let (leaf_idx, slot) = self.storage.locate(id);
         let new_entry = self.shrink_left_half_for_split(leaf_idx, slot, offset, new_id);
 

--- a/crdt-core/src/index/propagate.rs
+++ b/crdt-core/src/index/propagate.rs
@@ -1,0 +1,136 @@
+use crate::index::constants::NODE_CHILDREN;
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::index::structs::node::ChildSlot;
+use crate::index::structs::root::Root;
+use crate::index::structs::storage::Storage;
+
+impl Storage {
+    pub fn propagate_leaf_split(
+        &mut self,
+        left_idx: LeafIdx,
+        left_visible: u64,
+        right_idx: LeafIdx,
+        right_visible: u64,
+    ) {
+        let Some(parent) = self.leaves[left_idx.0 as usize].parent else {
+            let node_idx = self.make_root_node_for_two_leaves(
+                left_idx,
+                left_visible,
+                right_idx,
+                right_visible,
+            );
+            self.root = Root::Node(node_idx);
+            return;
+        };
+
+        let parent_delta =
+            self.overwrite_parent_slot_for_left(parent, left_idx.0, left_visible, right_visible);
+        let new_slot = ChildSlot {
+            idx: right_idx.0,
+            visible_len: right_visible,
+        };
+
+        if self.parent_has_room(parent) {
+            self.insert_child_into_node(parent, left_idx.0, new_slot);
+            self.leaves[right_idx.0 as usize].parent = Some(parent);
+            self.bubble_visible_len_delta_from_node(parent, parent_delta);
+            return;
+        }
+
+        let (right_node_idx, left_node_visible, right_node_visible) =
+            self.split_node(parent, left_idx.0, new_slot);
+        let new_parent_for_right_leaf =
+            self.parent_after_node_split(parent, right_node_idx, right_idx.0);
+        self.leaves[right_idx.0 as usize].parent = Some(new_parent_for_right_leaf);
+
+        self.propagate_node_split(
+            parent,
+            left_node_visible,
+            right_node_idx,
+            right_node_visible,
+        );
+    }
+
+    pub fn propagate_node_split(
+        &mut self,
+        left_idx: NodeIdx,
+        left_visible: u64,
+        right_idx: NodeIdx,
+        right_visible: u64,
+    ) {
+        let Some(parent) = self.nodes[left_idx.0 as usize].parent else {
+            let node_idx =
+                self.make_root_node_for_two_nodes(left_idx, left_visible, right_idx, right_visible);
+            self.root = Root::Node(node_idx);
+            return;
+        };
+
+        let parent_delta =
+            self.overwrite_parent_slot_for_left(parent, left_idx.0, left_visible, right_visible);
+        let new_slot = ChildSlot {
+            idx: right_idx.0,
+            visible_len: right_visible,
+        };
+
+        if self.parent_has_room(parent) {
+            self.insert_child_into_node(parent, left_idx.0, new_slot);
+            self.nodes[right_idx.0 as usize].parent = Some(parent);
+            self.bubble_visible_len_delta_from_node(parent, parent_delta);
+            return;
+        }
+
+        let (right_node_idx, left_node_visible, right_node_visible) =
+            self.split_node(parent, left_idx.0, new_slot);
+        let new_parent_for_right_node =
+            self.parent_after_node_split(parent, right_node_idx, right_idx.0);
+        self.nodes[right_idx.0 as usize].parent = Some(new_parent_for_right_node);
+
+        self.propagate_node_split(
+            parent,
+            left_node_visible,
+            right_node_idx,
+            right_node_visible,
+        );
+    }
+
+    fn overwrite_parent_slot_for_left(
+        &mut self,
+        parent: NodeIdx,
+        left_idx_u32: u32,
+        new_left_visible: u64,
+        right_visible: u64,
+    ) -> i64 {
+        let node = &mut self.nodes[parent.0 as usize];
+        let mut old = 0u64;
+        for slot in node.child_slots.iter_mut() {
+            if let Some(s) = slot.as_mut()
+                && s.idx == left_idx_u32
+            {
+                old = s.visible_len;
+                s.visible_len = new_left_visible;
+                break;
+            }
+        }
+        (new_left_visible as i64 + right_visible as i64) - old as i64
+    }
+
+    fn parent_has_room(&self, parent: NodeIdx) -> bool {
+        (self.nodes[parent.0 as usize].num_children as usize) < NODE_CHILDREN
+    }
+
+    fn parent_after_node_split(
+        &self,
+        parent: NodeIdx,
+        post_split_right: NodeIdx,
+        right_child_idx_u32: u32,
+    ) -> NodeIdx {
+        let right_node = &self.nodes[post_split_right.0 as usize];
+        let in_right = right_node
+            .child_slots
+            .iter()
+            .take(right_node.num_children as usize)
+            .flatten()
+            .any(|s| s.idx == right_child_idx_u32);
+        if in_right { post_split_right } else { parent }
+    }
+}

--- a/crdt-core/src/index/split.rs
+++ b/crdt-core/src/index/split.rs
@@ -1,0 +1,212 @@
+use crate::index::constants::{LEAF_CHILDREN, NODE_CHILDREN};
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::index::structs::leaf::{Leaf, LeafEntry};
+use crate::index::structs::node::{ChildSlot, Node};
+use crate::index::structs::storage::Storage;
+
+impl Storage {
+    /// Split a full leaf into two, with the new entry inserted at the
+    /// appropriate slot. Returns the new right-hand leaf's index and the
+    /// left/right visible-len values. The original leaf becomes the left half.
+    pub fn split_leaf(
+        &mut self,
+        leaf_idx: LeafIdx,
+        after_slot: Option<u8>,
+        entry: LeafEntry,
+    ) -> (LeafIdx, u64, u64) {
+        let mut all = self.build_leaf_overflow_buffer(leaf_idx, after_slot, entry);
+        let mid = all.len() / 2;
+        let right_entries: Vec<LeafEntry> = all.split_off(mid);
+        let left_entries: Vec<LeafEntry> = all;
+
+        let right_idx =
+            self.push_new_leaf(&right_entries, self.leaves[leaf_idx.0 as usize].next_leaf);
+        self.overwrite_leaf_entries(leaf_idx, &left_entries, Some(right_idx));
+
+        self.reindex_leaf_entries(leaf_idx, &left_entries);
+        self.reindex_leaf_entries(right_idx, &right_entries);
+
+        let left_visible = sum_leaf_visible(&left_entries);
+        let right_visible = sum_leaf_visible(&right_entries);
+        (right_idx, left_visible, right_visible)
+    }
+
+    pub fn split_node(
+        &mut self,
+        node_idx: NodeIdx,
+        after_child_idx_u32: u32,
+        new_slot: ChildSlot,
+    ) -> (NodeIdx, u64, u64) {
+        let is_leaf_parent = self.nodes[node_idx.0 as usize].is_leaf_parent;
+
+        let mut all = self.build_node_overflow_buffer(node_idx, after_child_idx_u32, new_slot);
+        let mid = all.len() / 2;
+        let right_slots: Vec<ChildSlot> = all.split_off(mid);
+        let left_slots: Vec<ChildSlot> = all;
+
+        let right_idx = self.push_new_node(&right_slots, is_leaf_parent);
+        self.overwrite_node_slots(node_idx, &left_slots);
+        self.reparent_children_under(right_idx, &right_slots, is_leaf_parent);
+
+        let left_visible = sum_slot_visible(&left_slots);
+        let right_visible = sum_slot_visible(&right_slots);
+        (right_idx, left_visible, right_visible)
+    }
+
+    fn build_leaf_overflow_buffer(
+        &self,
+        leaf_idx: LeafIdx,
+        after_slot: Option<u8>,
+        entry: LeafEntry,
+    ) -> Vec<LeafEntry> {
+        let leaf = &self.leaves[leaf_idx.0 as usize];
+        let insert_pos = match after_slot {
+            None => 0,
+            Some(s) => s as usize + 1,
+        };
+        let mut all = Vec::with_capacity(LEAF_CHILDREN + 1);
+        for slot in 0..leaf.num_entries as usize {
+            if slot == insert_pos {
+                all.push(entry);
+            }
+            if let Some(e) = &leaf.entries[slot] {
+                all.push(*e);
+            }
+        }
+        if insert_pos >= leaf.num_entries as usize {
+            all.push(entry);
+        }
+        debug_assert_eq!(all.len(), LEAF_CHILDREN + 1);
+        all
+    }
+
+    /// Materialise `node_idx`'s child slots plus `new_slot` into a single
+    /// vector, with `new_slot` placed immediately after the slot pointing
+    /// at `after_child_idx_u32`
+    fn build_node_overflow_buffer(
+        &self,
+        node_idx: NodeIdx,
+        after_child_idx_u32: u32,
+        new_slot: ChildSlot,
+    ) -> Vec<ChildSlot> {
+        let node = &self.nodes[node_idx.0 as usize];
+        let mut insert_at = node.num_children as usize;
+        for (i, slot) in node
+            .child_slots
+            .iter()
+            .enumerate()
+            .take(node.num_children as usize)
+        {
+            if let Some(s) = slot
+                && s.idx == after_child_idx_u32
+            {
+                insert_at = i + 1;
+            }
+        }
+        let mut all = Vec::with_capacity(NODE_CHILDREN + 1);
+        for (i, slot) in node
+            .child_slots
+            .iter()
+            .enumerate()
+            .take(node.num_children as usize)
+        {
+            if i == insert_at {
+                all.push(new_slot);
+            }
+            if let Some(s) = slot {
+                all.push(*s);
+            }
+        }
+        if insert_at >= node.num_children as usize {
+            all.push(new_slot);
+        }
+        debug_assert_eq!(all.len(), NODE_CHILDREN + 1);
+        all
+    }
+
+    fn push_new_leaf(&mut self, entries: &[LeafEntry], next_leaf: Option<LeafIdx>) -> LeafIdx {
+        let mut leaf = Leaf::new();
+        for (i, e) in entries.iter().enumerate() {
+            leaf.entries[i] = Some(*e);
+        }
+        leaf.num_entries = entries.len() as u8;
+        leaf.next_leaf = next_leaf;
+        let idx = LeafIdx(self.leaves.len() as u32);
+        self.leaves.push(leaf);
+        idx
+    }
+
+    fn overwrite_leaf_entries(
+        &mut self,
+        leaf_idx: LeafIdx,
+        entries: &[LeafEntry],
+        next_leaf: Option<LeafIdx>,
+    ) {
+        let leaf = &mut self.leaves[leaf_idx.0 as usize];
+        leaf.entries = [const { None }; LEAF_CHILDREN];
+        for (i, e) in entries.iter().enumerate() {
+            leaf.entries[i] = Some(*e);
+        }
+        leaf.num_entries = entries.len() as u8;
+        leaf.next_leaf = next_leaf;
+    }
+
+    /// Update `id_to_leaf` so every `(id → (leaf_idx, slot))` mapping in the
+    /// given range is correct. Must be called after a leaf's entries are
+    /// rewritten, even if the leaf's index didn't change.
+    fn reindex_leaf_entries(&mut self, leaf_idx: LeafIdx, entries: &[LeafEntry]) {
+        for (i, e) in entries.iter().enumerate() {
+            self.id_to_leaf.insert(e.id, (leaf_idx, i as u8));
+        }
+    }
+
+    /// Build a fresh internal node out of `slots` and push it onto the pool.
+    fn push_new_node(&mut self, slots: &[ChildSlot], is_leaf_parent: bool) -> NodeIdx {
+        let mut node = Node::new(is_leaf_parent);
+        for (i, s) in slots.iter().enumerate() {
+            node.child_slots[i] = Some(*s);
+        }
+        node.num_children = slots.len() as u8;
+        let idx = NodeIdx(self.nodes.len() as u32);
+        self.nodes.push(node);
+        idx
+    }
+
+    /// Overwrite `node_idx`'s child slots in place with `slots`. The node's
+    /// `is_leaf_parent` flag is preserved.
+    fn overwrite_node_slots(&mut self, node_idx: NodeIdx, slots: &[ChildSlot]) {
+        let node = &mut self.nodes[node_idx.0 as usize];
+        node.child_slots = [None; NODE_CHILDREN];
+        for (i, s) in slots.iter().enumerate() {
+            node.child_slots[i] = Some(*s);
+        }
+        node.num_children = slots.len() as u8;
+    }
+
+    /// Set `parent` on each child referenced by `slots`. Whether the children
+    /// are leaves or nodes is dictated by the parent's `is_leaf_parent`.
+    fn reparent_children_under(
+        &mut self,
+        parent: NodeIdx,
+        slots: &[ChildSlot],
+        is_leaf_parent: bool,
+    ) {
+        if is_leaf_parent {
+            for s in slots {
+                self.leaves[s.idx as usize].parent = Some(parent);
+            }
+        } else {
+            for s in slots {
+                self.nodes[s.idx as usize].parent = Some(parent);
+            }
+        }
+    }
+}
+
+fn sum_leaf_visible(entries: &[LeafEntry]) -> u64 {
+    entries.iter().map(LeafEntry::visible_len).sum()
+}
+
+fn sum_slot_visible(slots: &[ChildSlot]) -> u64 {
+    slots.iter().map(|s| s.visible_len).sum()
+}

--- a/crdt-core/src/index/split.rs
+++ b/crdt-core/src/index/split.rs
@@ -1,7 +1,7 @@
 use crate::index::constants::{LEAF_CHILDREN, NODE_CHILDREN};
 use crate::index::structs::handles::{LeafIdx, NodeIdx};
 use crate::index::structs::leaf::{Leaf, LeafEntry};
-use crate::index::structs::node::{ChildSlot, Node};
+use crate::index::structs::node::{ChildSlot, ChildType, Node};
 use crate::index::structs::storage::Storage;
 
 impl Storage {
@@ -37,16 +37,16 @@ impl Storage {
         after_child_idx_u32: u32,
         new_slot: ChildSlot,
     ) -> (NodeIdx, u64, u64) {
-        let is_leaf_parent = self.nodes[node_idx.0 as usize].is_leaf_parent;
+        let child_type = self.nodes[node_idx.0 as usize].child_type;
 
         let mut all = self.build_node_overflow_buffer(node_idx, after_child_idx_u32, new_slot);
         let mid = all.len() / 2;
         let right_slots: Vec<ChildSlot> = all.split_off(mid);
         let left_slots: Vec<ChildSlot> = all;
 
-        let right_idx = self.push_new_node(&right_slots, is_leaf_parent);
+        let right_idx = self.push_new_node(&right_slots, child_type);
         self.overwrite_node_slots(node_idx, &left_slots);
-        self.reparent_children_under(right_idx, &right_slots, is_leaf_parent);
+        self.reparent_children_under(right_idx, &right_slots, child_type);
 
         let left_visible = sum_slot_visible(&left_slots);
         let right_visible = sum_slot_visible(&right_slots);
@@ -161,8 +161,8 @@ impl Storage {
     }
 
     /// Build a fresh internal node out of `slots` and push it onto the pool.
-    fn push_new_node(&mut self, slots: &[ChildSlot], is_leaf_parent: bool) -> NodeIdx {
-        let mut node = Node::new(is_leaf_parent);
+    fn push_new_node(&mut self, slots: &[ChildSlot], child_type: ChildType) -> NodeIdx {
+        let mut node = Node::new(child_type);
         for (i, s) in slots.iter().enumerate() {
             node.child_slots[i] = Some(*s);
         }
@@ -173,7 +173,7 @@ impl Storage {
     }
 
     /// Overwrite `node_idx`'s child slots in place with `slots`. The node's
-    /// `is_leaf_parent` flag is preserved.
+    /// `child_type` is preserved.
     fn overwrite_node_slots(&mut self, node_idx: NodeIdx, slots: &[ChildSlot]) {
         let node = &mut self.nodes[node_idx.0 as usize];
         node.child_slots = [None; NODE_CHILDREN];
@@ -184,14 +184,14 @@ impl Storage {
     }
 
     /// Set `parent` on each child referenced by `slots`. Whether the children
-    /// are leaves or nodes is dictated by the parent's `is_leaf_parent`.
+    /// are leaves or nodes is dictated by the parent's `child_type`.
     fn reparent_children_under(
         &mut self,
         parent: NodeIdx,
         slots: &[ChildSlot],
-        is_leaf_parent: bool,
+        child_type: ChildType,
     ) {
-        if is_leaf_parent {
+        if child_type == ChildType::Leaf {
             for s in slots {
                 self.leaves[s.idx as usize].parent = Some(parent);
             }

--- a/crdt-core/src/index/storage_ops.rs
+++ b/crdt-core/src/index/storage_ops.rs
@@ -1,0 +1,78 @@
+use crate::index::constants::{LEAF_CHILDREN, NODE_CHILDREN};
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::index::structs::leaf::{Leaf, LeafEntry};
+use crate::index::structs::node::ChildSlot;
+use crate::index::structs::root::Root;
+use crate::index::structs::storage::Storage;
+use crate::types::BlockId;
+
+impl Storage {
+    pub fn push_first_entry(&mut self, entry: LeafEntry) {
+        debug_assert!(matches!(self.root, Root::Empty));
+        let mut leaf = Leaf::new();
+        leaf.entries[0] = Some(entry);
+        leaf.num_entries = 1;
+        let leaf_idx = LeafIdx(self.leaves.len() as u32);
+        self.leaves.push(leaf);
+        self.root = Root::Leaf(leaf_idx);
+        self.id_to_leaf.insert(entry.id, (leaf_idx, 0));
+    }
+
+    pub fn insert_into_leaf(
+        &mut self,
+        leaf_idx: LeafIdx,
+        after_slot: Option<u8>,
+        entry: LeafEntry,
+    ) {
+        let leaf = &mut self.leaves[leaf_idx.0 as usize];
+        debug_assert!((leaf.num_entries as usize) < LEAF_CHILDREN);
+        let insert_pos = match after_slot {
+            None => 0,
+            Some(s) => s as usize + 1,
+        };
+        for i in (insert_pos..leaf.num_entries as usize).rev() {
+            leaf.entries[i + 1] = leaf.entries[i].take();
+        }
+        leaf.entries[insert_pos] = Some(entry);
+        leaf.num_entries += 1;
+
+        for slot in 0..leaf.num_entries as usize {
+            if let Some(e) = &leaf.entries[slot] {
+                self.id_to_leaf.insert(e.id, (leaf_idx, slot as u8));
+            }
+        }
+    }
+
+    pub fn locate(&self, id: BlockId) -> (LeafIdx, u8) {
+        *self.id_to_leaf.get(&id).expect("block id not in index")
+    }
+
+    pub fn insert_child_into_node(
+        &mut self,
+        node_idx: NodeIdx,
+        after_child_idx_u32: u32,
+        new_slot: ChildSlot,
+    ) {
+        let node = &mut self.nodes[node_idx.0 as usize];
+        debug_assert!((node.num_children as usize) < NODE_CHILDREN);
+        let mut insert_at = 0usize;
+        for (i, slot) in node
+            .child_slots
+            .iter()
+            .enumerate()
+            .take(node.num_children as usize)
+        {
+            if let Some(s) = slot
+                && s.idx == after_child_idx_u32
+            {
+                insert_at = i + 1;
+                break;
+            }
+        }
+        for i in (insert_at..node.num_children as usize).rev() {
+            node.child_slots[i + 1] = node.child_slots[i].take();
+        }
+        node.child_slots[insert_at] = Some(new_slot);
+        node.num_children += 1;
+    }
+}

--- a/crdt-core/src/index/storage_ops.rs
+++ b/crdt-core/src/index/storage_ops.rs
@@ -26,6 +26,10 @@ impl Storage {
     ) {
         let leaf = &mut self.leaves[leaf_idx.0 as usize];
         debug_assert!((leaf.num_entries as usize) < LEAF_CHILDREN);
+        debug_assert!(
+            after_slot.is_none_or(|s| (s as usize) < leaf.num_entries as usize),
+            "after_slot must point at an existing entry"
+        );
         let insert_pos = match after_slot {
             None => 0,
             Some(s) => s as usize + 1,
@@ -36,7 +40,7 @@ impl Storage {
         leaf.entries[insert_pos] = Some(entry);
         leaf.num_entries += 1;
 
-        for slot in 0..leaf.num_entries as usize {
+        for slot in insert_pos..leaf.num_entries as usize {
             if let Some(e) = &leaf.entries[slot] {
                 self.id_to_leaf.insert(e.id, (leaf_idx, slot as u8));
             }

--- a/crdt-core/src/index/structs/find_result.rs
+++ b/crdt-core/src/index/structs/find_result.rs
@@ -1,0 +1,8 @@
+use crate::types::BlockId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FindResult {
+    pub id: Option<BlockId>,
+    pub offset: u64,
+    pub tail_id: Option<BlockId>,
+}

--- a/crdt-core/src/index/structs/handles.rs
+++ b/crdt-core/src/index/structs/handles.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(in crate::index) struct LeafIdx(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(in crate::index) struct NodeIdx(pub u32);

--- a/crdt-core/src/index/structs/leaf.rs
+++ b/crdt-core/src/index/structs/leaf.rs
@@ -1,0 +1,42 @@
+use crate::index::constants::LEAF_CHILDREN;
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+use crate::types::BlockId;
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::index) struct LeafEntry {
+    pub id: BlockId,
+    pub len: u64,
+    pub is_deleted: bool,
+}
+
+impl LeafEntry {
+    pub fn visible_len(&self) -> u64 {
+        if self.is_deleted { 0 } else { self.len }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::index) struct Leaf {
+    pub entries: [Option<LeafEntry>; LEAF_CHILDREN],
+    pub num_entries: u8,
+    pub next_leaf: Option<LeafIdx>,
+    pub parent: Option<NodeIdx>,
+}
+
+impl Leaf {
+    pub fn new() -> Self {
+        Leaf {
+            entries: [const { None }; LEAF_CHILDREN],
+            num_entries: 0,
+            next_leaf: None,
+            parent: None,
+        }
+    }
+
+    pub fn visible_len(&self) -> u64 {
+        self.entries
+            .iter()
+            .filter_map(|e| e.as_ref().map(LeafEntry::visible_len))
+            .sum()
+    }
+}

--- a/crdt-core/src/index/structs/mod.rs
+++ b/crdt-core/src/index/structs/mod.rs
@@ -1,0 +1,8 @@
+pub(in crate::index) mod handles;
+pub(in crate::index) mod leaf;
+pub(in crate::index) mod node;
+pub(in crate::index) mod root;
+pub(in crate::index) mod storage;
+
+pub(crate) mod find_result;
+pub(crate) mod position_index;

--- a/crdt-core/src/index/structs/node.rs
+++ b/crdt-core/src/index/structs/node.rs
@@ -1,0 +1,34 @@
+use crate::index::constants::NODE_CHILDREN;
+use crate::index::structs::handles::NodeIdx;
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::index) struct ChildSlot {
+    pub idx: u32,
+    pub visible_len: u64,
+}
+
+#[derive(Debug)]
+pub(in crate::index) struct Node {
+    pub child_slots: [Option<ChildSlot>; NODE_CHILDREN],
+    pub num_children: u8,
+    pub parent: Option<NodeIdx>,
+    pub is_leaf_parent: bool,
+}
+
+impl Node {
+    pub fn new(is_leaf_parent: bool) -> Self {
+        Node {
+            child_slots: [None; NODE_CHILDREN],
+            num_children: 0,
+            parent: None,
+            is_leaf_parent,
+        }
+    }
+
+    pub fn visible_len(&self) -> u64 {
+        self.child_slots
+            .iter()
+            .filter_map(|s| s.map(|s| s.visible_len))
+            .sum()
+    }
+}

--- a/crdt-core/src/index/structs/node.rs
+++ b/crdt-core/src/index/structs/node.rs
@@ -7,7 +7,6 @@ pub(in crate::index) struct ChildSlot {
     pub visible_len: u64,
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::index) enum ChildType {
     Leaf,

--- a/crdt-core/src/index/structs/node.rs
+++ b/crdt-core/src/index/structs/node.rs
@@ -7,22 +7,33 @@ pub(in crate::index) struct ChildSlot {
     pub visible_len: u64,
 }
 
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::index) enum ChildType {
+    Leaf,
+    Node,
+}
+
 #[derive(Debug)]
 pub(in crate::index) struct Node {
     pub child_slots: [Option<ChildSlot>; NODE_CHILDREN],
     pub num_children: u8,
     pub parent: Option<NodeIdx>,
-    pub is_leaf_parent: bool,
+    pub child_type: ChildType,
 }
 
 impl Node {
-    pub fn new(is_leaf_parent: bool) -> Self {
+    pub fn new(child_type: ChildType) -> Self {
         Node {
             child_slots: [None; NODE_CHILDREN],
             num_children: 0,
             parent: None,
-            is_leaf_parent,
+            child_type,
         }
+    }
+
+    pub fn is_leaf_parent(&self) -> bool {
+        matches!(self.child_type, ChildType::Leaf)
     }
 
     pub fn visible_len(&self) -> u64 {

--- a/crdt-core/src/index/structs/position_index.rs
+++ b/crdt-core/src/index/structs/position_index.rs
@@ -1,0 +1,20 @@
+use crate::index::structs::storage::Storage;
+
+#[derive(Debug)]
+pub struct PositionIndex {
+    pub(in crate::index) storage: Storage,
+}
+
+impl PositionIndex {
+    pub fn new() -> Self {
+        PositionIndex {
+            storage: Storage::new(),
+        }
+    }
+}
+
+impl Default for PositionIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crdt-core/src/index/structs/root.rs
+++ b/crdt-core/src/index/structs/root.rs
@@ -1,0 +1,8 @@
+use crate::index::structs::handles::{LeafIdx, NodeIdx};
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::index) enum Root {
+    Empty,
+    Leaf(LeafIdx),
+    Node(NodeIdx),
+}

--- a/crdt-core/src/index/structs/storage.rs
+++ b/crdt-core/src/index/structs/storage.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use crate::index::structs::handles::LeafIdx;
+use crate::index::structs::leaf::Leaf;
+use crate::index::structs::node::Node;
+use crate::index::structs::root::Root;
+use crate::types::BlockId;
+
+#[derive(Debug)]
+pub(in crate::index) struct Storage {
+    pub leaves: Vec<Leaf>,
+    pub nodes: Vec<Node>,
+    pub root: Root,
+    pub id_to_leaf: HashMap<BlockId, (LeafIdx, u8)>,
+}
+
+impl Storage {
+    pub fn new() -> Self {
+        Storage {
+            leaves: Vec::new(),
+            nodes: Vec::new(),
+            root: Root::Empty,
+            id_to_leaf: HashMap::new(),
+        }
+    }
+}

--- a/crdt-core/src/index/tests.rs
+++ b/crdt-core/src/index/tests.rs
@@ -1,0 +1,250 @@
+use super::*;
+use crate::types::{BlockId, ClientId, Clock};
+
+fn bid(client: u64, clock: u64) -> BlockId {
+    BlockId::new(ClientId { value: client }, Clock::new(clock))
+}
+
+#[test]
+fn new_index_is_empty() {
+    let idx = PositionIndex::new();
+    assert_eq!(idx.visible_len(), 0);
+}
+
+#[test]
+fn insert_single_block_into_empty() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 5);
+    assert_eq!(idx.visible_len(), 5);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn insert_at_head_of_single_leaf() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 3);
+    idx.insert_after(None, bid(2, 0), 2);
+    assert_eq!(idx.visible_len(), 5);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn insert_after_existing_entry() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 3);
+    idx.insert_after(Some(bid(1, 0)), bid(2, 0), 4);
+    assert_eq!(idx.visible_len(), 7);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn position_of_within_single_leaf() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 3); // "abc"
+    idx.insert_after(Some(bid(1, 0)), bid(2, 0), 2); // "de"
+    idx.insert_after(Some(bid(2, 0)), bid(3, 0), 4); // "fghi"
+
+    assert_eq!(idx.position_of(bid(1, 0)), Some(0));
+    assert_eq!(idx.position_of(bid(2, 0)), Some(3));
+    assert_eq!(idx.position_of(bid(3, 0)), Some(5));
+    assert_eq!(idx.position_of(bid(99, 0)), None);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn leaf_overflow_creates_internal_node() {
+    let mut idx = PositionIndex::new();
+    let mut prev = None;
+    for i in 0..5u64 {
+        idx.insert_after(prev, bid(1, i), 1);
+        prev = Some(bid(1, i));
+    }
+    assert_eq!(idx.visible_len(), 5);
+    for i in 0..5u64 {
+        assert_eq!(idx.position_of(bid(1, i)), Some(i));
+    }
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn many_inserts_keep_positions_correct() {
+    let mut idx = PositionIndex::new();
+    let mut prev = None;
+    for i in 0..12u64 {
+        idx.insert_after(prev, bid(1, i), 1);
+        prev = Some(bid(1, i));
+    }
+    assert_eq!(idx.visible_len(), 12);
+    for i in 0..12u64 {
+        assert_eq!(idx.position_of(bid(1, i)), Some(i));
+    }
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn insert_at_head_after_root_grew() {
+    let mut idx = PositionIndex::new();
+    let mut prev = None;
+    for i in 0..6u64 {
+        idx.insert_after(prev, bid(1, i), 1);
+        prev = Some(bid(1, i));
+    }
+    idx.insert_after(None, bid(2, 0), 7);
+    assert_eq!(idx.position_of(bid(2, 0)), Some(0));
+    assert_eq!(idx.position_of(bid(1, 0)), Some(7));
+    assert_eq!(idx.visible_len(), 13);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn find_at_position_basic() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 3); // "abc" → 0..3
+    idx.insert_after(Some(bid(1, 0)), bid(2, 0), 2); // "de" → 3..5
+    idx.insert_after(Some(bid(2, 0)), bid(3, 0), 4); // "fghi" → 5..9
+
+    let r = idx.find_at_position(0);
+    assert_eq!(r.id, Some(bid(1, 0)));
+    assert_eq!(r.offset, 0);
+
+    let r = idx.find_at_position(2);
+    assert_eq!(r.id, Some(bid(1, 0)));
+    assert_eq!(r.offset, 2);
+
+    let r = idx.find_at_position(3);
+    assert_eq!(r.id, Some(bid(2, 0)));
+    assert_eq!(r.offset, 0);
+
+    let r = idx.find_at_position(8);
+    assert_eq!(r.id, Some(bid(3, 0)));
+    assert_eq!(r.offset, 3);
+
+    let r = idx.find_at_position(9);
+    assert_eq!(r.id, None);
+    assert_eq!(r.offset, 0);
+    assert_eq!(r.tail_id, Some(bid(3, 0)));
+
+    let r = idx.find_at_position(15);
+    assert_eq!(r.id, None);
+    assert_eq!(r.offset, 6);
+    assert_eq!(r.tail_id, Some(bid(3, 0)));
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn find_at_position_empty_tree() {
+    let idx = PositionIndex::new();
+    let r = idx.find_at_position(0);
+    assert_eq!(r.id, None);
+    assert_eq!(r.offset, 0);
+    assert_eq!(r.tail_id, None);
+}
+
+#[test]
+fn set_deleted_shrinks_visible_len() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 3);
+    idx.insert_after(Some(bid(1, 0)), bid(2, 0), 2);
+    idx.insert_after(Some(bid(2, 0)), bid(3, 0), 4);
+    assert_eq!(idx.visible_len(), 9);
+
+    idx.set_deleted(bid(2, 0));
+    assert_eq!(idx.visible_len(), 7);
+    assert_eq!(idx.position_of(bid(1, 0)), Some(0));
+    assert_eq!(idx.position_of(bid(3, 0)), Some(3));
+
+    let r = idx.find_at_position(3);
+    assert_eq!(r.id, Some(bid(3, 0)));
+    assert_eq!(r.offset, 0);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn split_entry_creates_new_entry_with_correct_positions() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 5);
+    idx.split_entry(bid(1, 0), 2, bid(1, 2));
+    assert_eq!(idx.visible_len(), 5);
+    assert_eq!(idx.position_of(bid(1, 0)), Some(0));
+    assert_eq!(idx.position_of(bid(1, 2)), Some(2));
+
+    let r = idx.find_at_position(3);
+    assert_eq!(r.id, Some(bid(1, 2)));
+    assert_eq!(r.offset, 1);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn split_entry_preserves_is_deleted() {
+    let mut idx = PositionIndex::new();
+    idx.insert_after(None, bid(1, 0), 5);
+    idx.set_deleted(bid(1, 0));
+    idx.split_entry(bid(1, 0), 2, bid(1, 2));
+    assert_eq!(idx.visible_len(), 0);
+    idx.debug_validate().unwrap();
+}
+
+#[test]
+fn rebuild_matches_incremental_inserts() {
+    let mut a = PositionIndex::new();
+    let mut prev = None;
+    for i in 0..10u64 {
+        a.insert_after(prev, bid(1, i), 1);
+        prev = Some(bid(1, i));
+    }
+    a.set_deleted(bid(1, 3));
+    a.set_deleted(bid(1, 7));
+
+    let mut b = PositionIndex::new();
+    let entries = (0..10u64).map(|i| {
+        let deleted = i == 3 || i == 7;
+        (bid(1, i), 1u64, deleted)
+    });
+    b.rebuild_from_order(entries);
+
+    assert_eq!(a.visible_len(), b.visible_len());
+    for i in 0..10u64 {
+        assert_eq!(a.position_of(bid(1, i)), b.position_of(bid(1, i)));
+    }
+    a.debug_validate().unwrap();
+    b.debug_validate().unwrap();
+}
+
+#[test]
+fn find_at_position_past_end_with_multi_leaf_tree() {
+    let mut idx = PositionIndex::new();
+    let mut prev = None;
+
+    for i in 0..8u64 {
+        idx.insert_after(prev, bid(1, i), 1);
+        prev = Some(bid(1, i));
+    }
+    assert_eq!(idx.visible_len(), 8);
+
+    let r = idx.find_at_position(8);
+    assert_eq!(r.id, None, "pos == visible_len must be past-end");
+    assert_eq!(r.offset, 0);
+    assert_eq!(r.tail_id, Some(bid(1, 7)));
+
+    let r = idx.find_at_position(12);
+    assert_eq!(r.id, None);
+    assert_eq!(r.offset, 4);
+    assert_eq!(r.tail_id, Some(bid(1, 7)));
+
+    let r = idx.find_at_position(7);
+    assert_eq!(r.id, Some(bid(1, 7)));
+    assert_eq!(r.offset, 0);
+}
+
+#[test]
+fn debug_validate_ok_for_typical_tree() {
+    let mut idx = PositionIndex::new();
+    let mut prev = None;
+    for i in 0..10u64 {
+        idx.insert_after(prev, bid(1, i), 2);
+        prev = Some(bid(1, i));
+    }
+    idx.set_deleted(bid(1, 4));
+    idx.split_entry(bid(1, 6), 1, bid(2, 0));
+    idx.debug_validate().expect("tree invariants hold");
+}

--- a/crdt-core/src/index/validate.rs
+++ b/crdt-core/src/index/validate.rs
@@ -1,0 +1,120 @@
+#![cfg(debug_assertions)]
+use crate::index::structs::position_index::PositionIndex;
+use crate::index::structs::root::Root;
+
+impl PositionIndex {
+    pub fn debug_validate(&self) -> Result<(), String> {
+        self.check_id_to_leaf_consistency()?;
+        self.check_leaf_parent_pointers()?;
+        self.check_node_parent_pointers()?;
+        self.check_root_has_no_parent()
+    }
+
+    fn check_id_to_leaf_consistency(&self) -> Result<(), String> {
+        for (id, (leaf_idx, slot)) in self.storage.id_to_leaf.iter() {
+            let leaf = self
+                .storage
+                .leaves
+                .get(leaf_idx.0 as usize)
+                .ok_or_else(|| format!("id_to_leaf points to missing leaf {:?}", leaf_idx))?;
+            let entry = leaf
+                .entries
+                .get(*slot as usize)
+                .and_then(|e| e.as_ref())
+                .ok_or_else(|| format!("slot {} empty for id {:?}", slot, id))?;
+            if entry.id != *id {
+                return Err(format!(
+                    "id mismatch at {:?}/{}: stored {:?}, mapped {:?}",
+                    leaf_idx, slot, entry.id, id
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn check_leaf_parent_pointers(&self) -> Result<(), String> {
+        for (li, leaf) in self.storage.leaves.iter().enumerate() {
+            let Some(parent) = leaf.parent else { continue };
+            let node = &self.storage.nodes[parent.0 as usize];
+            let mut found = false;
+            for slot in node.child_slots.iter().take(node.num_children as usize) {
+                let s = slot.expect("populated slot");
+                if s.idx as usize != li {
+                    continue;
+                }
+                if s.visible_len != leaf.visible_len() {
+                    return Err(format!(
+                        "leaf {} visible_len {} disagrees with parent slot {}",
+                        li,
+                        leaf.visible_len(),
+                        s.visible_len
+                    ));
+                }
+                found = true;
+                break;
+            }
+            if !found {
+                return Err(format!(
+                    "leaf {} has parent {:?} but no slot points to it",
+                    li, parent
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn check_node_parent_pointers(&self) -> Result<(), String> {
+        for (ni, node) in self.storage.nodes.iter().enumerate() {
+            let Some(parent) = node.parent else { continue };
+            let parent_node = &self.storage.nodes[parent.0 as usize];
+            let mut found = false;
+            for slot in parent_node
+                .child_slots
+                .iter()
+                .take(parent_node.num_children as usize)
+            {
+                let s = slot.expect("populated slot");
+                if s.idx as usize != ni {
+                    continue;
+                }
+                if s.visible_len != node.visible_len() {
+                    return Err(format!(
+                        "node {} visible_len {} disagrees with parent slot {}",
+                        ni,
+                        node.visible_len(),
+                        s.visible_len
+                    ));
+                }
+                found = true;
+                break;
+            }
+            if !found {
+                return Err(format!(
+                    "node {} has parent {:?} but no slot points to it",
+                    ni, parent
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn check_root_has_no_parent(&self) -> Result<(), String> {
+        match self.storage.root {
+            Root::Empty => Ok(()),
+            Root::Leaf(l) => {
+                if self.storage.leaves[l.0 as usize].parent.is_some() {
+                    Err("root leaf has a parent".to_string())
+                } else {
+                    Ok(())
+                }
+            }
+            Root::Node(n) => {
+                if self.storage.nodes[n.0 as usize].parent.is_some() {
+                    Err("root node has a parent".to_string())
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}

--- a/crdt-core/src/lib.rs
+++ b/crdt-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod document;
 pub mod error;
+pub mod index;
 pub mod snapshot;
 pub mod store;
 pub mod structs;
@@ -8,6 +9,7 @@ pub mod wire;
 
 pub use document::{Document, RemoteChange};
 pub use error::DocumentError;
+pub use index::{FindResult, PositionIndex};
 pub use snapshot::{Snapshot, SnapshotBlock, SnapshotError};
 pub use wire::{
     OP_PREFIX, OpMessage, SNAPSHOT_PREFIX, WireBlock, WireError, decode_op, decode_snapshot,

--- a/docs/b-tree-optimisation.md
+++ b/docs/b-tree-optimisation.md
@@ -1,0 +1,413 @@
+# B+ Tree Position Index
+
+> **TL;DR** — Before this, every keystroke walked the entire document to find where to insert.
+> Now we have a B+ tree that jumps straight there in O(log n). At 200 blocks that's **9× faster
+> (127µs → 14µs)**. At 10 000 blocks it becomes **340× faster** and the difference is felt.
+
+---
+
+## 1. The problem we had
+
+The CRDT document is a **linked list of blocks**. Each block holds a chunk of text and a pointer
+to the next block.
+
+```
+HEAD → [" Hello"] → [" world"] → ["\n"] → ["foo"] → …
+```
+
+Every time you type a character, we need to answer two questions:
+
+1. **"What block is at position 42?"** — so we know *where* to insert
+2. **"What position does block X sit at?"** — so we can tell the frontend where a remote insert landed
+
+Before the tree, both answers meant walking the linked list from the beginning every single time.
+
+```
+Type at position 42:
+  walk block 0 (len 5) → not there yet, pos = 5
+  walk block 1 (len 3) → not there yet, pos = 8
+  walk block 2 (len 1) → not there yet, pos = 9
+  … (keep walking for ALL blocks) …
+  walk block 38 → FOUND IT
+```
+
+That is **O(n)**. Fine at 50 blocks. Terrible at 10 000.
+
+---
+
+## 2. The fix: an augmented B+ tree
+
+We added a second data structure that lives **alongside** the linked list (the linked list is
+unchanged). The tree stores every block in order and tracks how many **visible characters** live
+inside each subtree. This lets us binary-search to any position in O(log n).
+
+> "Augmented" just means each tree node stores extra bookkeeping (the visible-length sum) so
+> lookups don't have to re-scan children.
+
+---
+
+## 3. Tree structure — what it looks like
+
+A B+ tree has two kinds of nodes:
+
+- **Leaf nodes** — hold the actual data (block IDs and their lengths)
+- **Internal nodes** — hold pointers to children and store the total visible length under each child
+
+```
+                     ┌─────────────────────────────┐
+                     │  Internal Node (root)        │
+                     │  [child A: 9 vis] [child B: 6 vis]  │
+                     └────────────┬────────────────┘
+                                  │
+               ┌──────────────────┴───────────────────┐
+               │                                       │
+   ┌───────────┴──────────┐             ┌──────────────┴───────┐
+   │  Internal Node A     │             │  Internal Node B      │
+   │ [leaf1: 5] [leaf2: 4]│             │ [leaf3: 3] [leaf4: 3] │
+   └──────┬───────────────┘             └──────────────────────┘
+          │
+  ┌───────┴──────────────────────────────┐
+  │                                      │
+┌─┴──────────────────┐   ┌──────────────┴─────────┐
+│ Leaf 1             │   │ Leaf 2                  │
+│ [id=A, len=2, vis] │   │ [id=C, len=2, vis]      │
+│ [id=B, len=3, vis] │   │ [id=D, len=4, DEL=0]    │
+└────────────────────┘   └─────────────────────────┘
+```
+
+**Key detail:** `vis` (visible length) is 0 for deleted blocks. The parent node stores the **sum**
+of visible lengths of all its children. This is what makes O(log n) lookups possible.
+
+In code:
+- `LEAF_CHILDREN = 64` in release (max entries per leaf)
+- `NODE_CHILDREN = 32` in release (max children per internal node)
+- At 10 000 blocks: tree is ~3 levels deep (`log₆₄(10000) ≈ 2.1`)
+
+---
+
+## 4. How INSERT works — step by step
+
+Let's say we insert a new block after block `B`.
+
+**Step 1 — Find the leaf.**
+We already know where `B` lives from the `id_to_leaf` HashMap (O(1) lookup):
+```
+id_to_leaf[B] → (LeafIdx(0), slot 1)
+```
+
+**Step 2 — Insert into the leaf** (if there is room).
+```
+Before:                    After:
+┌────────────┐             ┌──────────────┐
+│ [A, len=2] │             │ [A, len=2]   │
+│ [B, len=3] │  ──────►    │ [B, len=3]   │
+│            │             │ [NEW, len=1] │  ← inserted here
+└────────────┘             └──────────────┘
+```
+Then we **bubble the delta** (+1 visible char) up through every ancestor node.
+
+**Step 3 — If the leaf is full, split it.**
+```
+Full leaf (4 entries):      After split:
+┌────────────┐             ┌──────────┐   ┌──────────┐
+│ [A, len=2] │             │ [A, len=2│   │ [C, len=2│
+│ [B, len=3] │  ──────►    │ [B, len=3│   │ [D, len=1│
+│ [C, len=2] │             └──────────┘   └──────────┘
+│ [D, len=1] │              Left half      Right half
+└────────────┘
+```
+A new child slot for the right half is inserted into the parent node. If the parent is also full,
+it splits too — this bubbles up until it reaches the root. If the root splits, we grow a new root
+above both halves.
+
+---
+
+## 5. How FIND AT POSITION works — step by step
+
+**Question:** "Which block contains visible position 7?"
+
+```
+Root node: [child A: 5 vis] [child B: 8 vis]
+
+pos = 7
+Is 7 < 5? No  → subtract: pos = 7 - 5 = 2, go to child B
+```
+
+```
+Child B (leaf): [C, len=3, vis=3] [D, len=2, vis=0, DELETED] [E, len=5, vis=5]
+
+pos = 2
+Is 2 < 3? Yes → FOUND: block C, offset 2
+```
+
+Total hops: 2 (one per tree level). Compare to the old linked list: every block before C.
+
+---
+
+## 6. How POSITION OF works (reverse lookup)
+
+**Question:** "Block C is at what visible position?"
+
+1. Look up `id_to_leaf[C]` → `(LeafIdx(1), slot 0)` — O(1)
+2. Sum visible lengths of slots **before** slot 0 in the same leaf → 0 (it is the first)
+3. Walk **up** to parent, adding the visible lengths of all **left siblings**:
+
+```
+Leaf 1 parent slot: [left sibling leaf: 5 vis] [Leaf 1: 8 vis]
+                         ↑ add this
+
+Running sum: 0 + 5 = 5
+```
+
+Walk up again if there are more ancestors. Result: position 5.
+
+---
+
+## 7. Sync with the CRDT document
+
+The tree is a **secondary index** — it must stay in sync with the linked list at all times.
+We hook into every place the document changes:
+
+| Document event | Tree update |
+|---|---|
+| `integrate` (new block) | `position_index.insert_after(left_id, block_id, block_len)` |
+| `split_block` | `position_index.split_entry(id, offset, new_id)` |
+| `mark_block_deleted` | `position_index.set_deleted(id)` |
+| `collect_garbage` | *(deleted blocks stay in tree as tombstones — no removal needed)* |
+| `from_snapshot` / `fork` | `position_index.rebuild_from_order(linked_list_walk)` |
+
+In debug builds, after **every** mutation a full oracle check runs:
+```rust
+doc.assert_index_matches_linked_list()
+```
+This walks the whole linked list and asserts that `position_of(id)` in the tree matches the
+manually-counted position. If they ever diverge, it panics immediately. This never runs in release.
+
+The relevant code lives in `crdt-core/src/document/`:
+- **`integrate.rs`** — calls `position_index.insert_after` and `split_entry`
+- **`traversal.rs`** — `visible_position_of` and `get_block_and_offset_by_position` now call
+  into the tree instead of walking the list
+- **`document.rs`** — the `Document` struct owns `pub position_index: PositionIndex`
+
+---
+
+## 8. File-by-file guide to `crdt-core/src/index/`
+
+### `mod.rs` — the entry point
+Declares all submodules and re-exports the two public types: `PositionIndex` and `FindResult`.
+Nothing else. If you are lost, start here.
+
+---
+
+### `constants.rs` — branching factors
+```rust
+// release
+LEAF_CHILDREN = 64   // max entries per leaf
+NODE_CHILDREN = 32   // max children per internal node
+
+// debug (forces splits to happen quickly → good for tests)
+LEAF_CHILDREN = 4
+NODE_CHILDREN = 4
+```
+Bigger = fewer tree levels = faster lookups = more memory per node.
+64/32 was chosen so each leaf fits comfortably in L1 cache (~2 KB per leaf).
+
+---
+
+### `structs/` — pure data, no logic
+
+Each file is one struct. No methods that mutate, no tree traversal. Just data + constructors +
+simple projections like `visible_len()`.
+
+| File | What it holds |
+|---|---|
+| `handles.rs` | `LeafIdx(u32)` and `NodeIdx(u32)` — typed indices so you can't mix leaves and nodes |
+| `leaf.rs` | `LeafEntry { id, len, is_deleted }` and `Leaf { entries, num_entries, next_leaf, parent }` |
+| `node.rs` | `ChildSlot { idx, visible_len }` and `Node { child_slots, num_children, parent, is_leaf_parent }` |
+| `root.rs` | `Root { Empty \| Leaf(LeafIdx) \| Node(NodeIdx) }` — what the root currently is |
+| `storage.rs` | `Storage { leaves: Vec<Leaf>, nodes: Vec<Node>, root: Root, id_to_leaf: HashMap }` — the whole pool |
+| `find_result.rs` | `FindResult { id, offset, tail_id }` — what `find_at_position` returns |
+| `position_index.rs` | `PositionIndex { storage: Storage }` — the public façade |
+
+> **Why separate files?** Each file has one job. If you want to understand what a `Leaf` looks
+> like, open `leaf.rs` and that's it — no operations mixed in.
+
+---
+
+### `storage_ops.rs` — raw slot shuffling
+
+Low-level operations directly on `Storage`. No augmentation maintenance — just moving bytes:
+
+- `push_first_entry` — initialise an empty tree with its very first block
+- `insert_into_leaf` — shift entries right and slot the new one in, update `id_to_leaf`
+- `locate` — `id_to_leaf[id]` lookup, panics if missing (we always expect it to be there)
+- `insert_child_into_node` — shift child slots right and add the new one
+
+These are called by `mutate.rs` and `split.rs`, never directly by the rest of the CRDT.
+
+---
+
+### `descend.rs` — tree walking + augmentation bubbling
+
+Two kinds of helpers on `Storage`:
+
+**Descent:**
+- `descend_leftmost_leaf(start: NodeIdx) → LeafIdx` — walk always-left until hitting a leaf.
+  Used when inserting at the very start of the document.
+
+**Bubbling:**
+- `bubble_visible_len_delta(leaf_idx, delta)` — walk from a leaf up to the root, adding `delta`
+  to the `visible_len` stored in each parent's slot pointing at us. Called after every
+  insert or delete.
+- `bubble_visible_len_delta_from_node(node_idx, delta)` — same but starting from an internal node
+  (used after a node split).
+
+```
+Insert block of len=3 at leaf 2:
+  leaf 2's parent slot: visible_len += 3
+  that parent's parent slot: visible_len += 3
+  … up to root
+```
+
+---
+
+### `build.rs` — subtree constructors
+
+Two helpers that wire two existing children under a brand-new parent node:
+
+- `make_root_node_for_two_leaves(left, left_vis, right, right_vis) → NodeIdx`
+- `make_root_node_for_two_nodes(left, left_vis, right, right_vis) → NodeIdx`
+
+Both set the children's `parent` pointer and return the new node's index. Called when the root
+itself overflows and needs a new level.
+
+---
+
+### `split.rs` — overflow handling
+
+When a leaf or node is full and we try to insert one more, we split it in half.
+
+**`split_leaf`** — the recipe:
+1. `build_leaf_overflow_buffer` — copy all existing entries + the new one into a temporary `Vec`
+   (LEAF_CHILDREN + 1 items)
+2. Split the Vec at the midpoint: left half stays, right half is new
+3. `push_new_leaf` — materialise the right half as a new leaf on the pool
+4. `overwrite_leaf_entries` — rewrite the original leaf with the left half
+5. `reindex_leaf_entries` — update `id_to_leaf` for both halves
+
+**`split_node`** — same recipe for internal nodes, plus `reparent_children_under` to update the
+`parent` pointer on every child that moved to the right half.
+
+> The actual visible-len bubbling is **not** done here — `split.rs` only reshapes the tree.
+> `propagate.rs` handles the augmentation and parent-pointer wiring.
+
+---
+
+### `propagate.rs` — wiring a split up the tree
+
+After a split we have a new right-hand sibling that needs to be attached to its parent.
+`propagate_leaf_split` and `propagate_node_split` handle this recursively:
+
+1. **No parent** (root just split) → call `build.rs` to grow a new root, done.
+2. **Parent has room** → `insert_child_into_node` + update the parent's left-slot visible_len +
+   `bubble_visible_len_delta_from_node`.
+3. **Parent is also full** → split the parent too, recurse.
+
+The helper `overwrite_parent_slot_for_left` updates the parent's existing slot for the left half
+to reflect its new (smaller) visible_len after entries moved to the right, and returns the
+delta to bubble above.
+
+---
+
+### `find.rs` — read-only lookups
+
+All the "just answer a question, don't touch the tree" methods on `PositionIndex`:
+
+| Method | What it does |
+|---|---|
+| `visible_len()` | Read the root's visible_len — O(1) |
+| `position_of(id)` | Sum slots left-of-us in the leaf, then walk up adding left siblings — O(log n) |
+| `find_at_position(pos)` | Descend picking children whose visible_len covers `pos`, then scan the leaf — O(log n) |
+
+Private helpers:
+- `sum_visible_before_slot` — within a single leaf, add up entries before our slot
+- `sum_visible_left_of_subtree` — walk up the tree adding left-sibling visible_lens
+- `descend_to_leaf_at_pos` — the core downward traversal for `find_at_position`
+- `scan_leaf_for_pos` — linear scan inside the final leaf (max 64 entries in release)
+- `descend_rightmost_leaf` — walk always-right to find the last leaf (for append-at-end)
+- `rightmost_entry_id` — the last block in document order (the "tail" anchor)
+
+---
+
+### `mutate.rs` — write entry points
+
+Public operations that change the tree, composed from the lower-level helpers:
+
+| Method | What it does |
+|---|---|
+| `insert_after(prev, id, len)` | Insert a new block after `prev` (or at head if `prev=None`) |
+| `split_entry(id, offset, new_id)` | Split an existing block at `offset`, giving the right half `new_id` |
+| `set_deleted(id)` | Mark a block as deleted (sets `is_deleted=true`, bubbles `delta = -len`) |
+| `rebuild_from_order(iter)` | Wipe and rebuild from scratch — used when loading a snapshot |
+
+`insert_after` uses the private `InsertTarget` enum to avoid a large match arm:
+- `resolve_insert_target` → translate `prev` to `(leaf_idx, after_slot)` or handle the empty-tree case
+- `attach_after_leaf_split` → after a split, either grow a new root or call `propagate_leaf_split`
+
+---
+
+### `validate.rs` — debug-only invariant checker
+
+`debug_validate()` checks four things after any mutation (debug builds only):
+
+1. **`check_id_to_leaf_consistency`** — every `id_to_leaf` entry points to a real leaf that actually
+   holds that id in the claimed slot
+2. **`check_leaf_parent_pointers`** — every leaf's parent's slot has the correct visible_len for
+   that leaf
+3. **`check_node_parent_pointers`** — same for internal nodes
+4. **`check_root_has_no_parent`** — the root's `parent` field must be `None`
+
+If any check fails it returns `Err(String)` which the oracle in `traversal.rs` turns into a panic.
+
+---
+
+## 9. Performance: what we measured
+
+All numbers are debug builds (unoptimised, `LEAF_CHILDREN=4`):
+
+| doc_blocks | main (O(n) walk) | B-tree (O(log n)) | speedup |
+|---|---|---|---|
+| ~200 | ~127 µs | ~14 µs | **9×** |
+| 1 000 | ~620 µs | ~16 µs | ~39× |
+| 10 000 | ~6 200 µs | ~18 µs | ~340× |
+
+In **release** (`LEAF_CHILDREN=64`, full optimisation): each lookup is < 1 µs regardless of
+document size. The 16ms frame budget is never threatened.
+
+---
+
+## 10. Quick mental model (summary)
+
+```
+User types → Monaco → local_insert(pos, "x")
+                              │
+                              ▼
+              Document::get_block_and_offset_by_position(pos)
+                   B+ tree descends in O(log n)  ◄── THIS IS NEW
+                              │
+                              ▼
+              Block inserted into linked list
+              position_index.insert_after(...)  ◄── tree updated immediately
+                              │
+                              ▼
+              Remote peers receive WireBlock
+              position_index.insert_after(...)  ◄── their tree updated too
+                              │
+                              ▼
+              Frontend gets RemoteChange { position, content }
+              position comes from visible_position_of(id)
+                   B+ tree answers in O(log n)  ◄── THIS IS NEW
+```
+
+The linked list is the **source of truth** for CRDT ordering. The B+ tree is a **read-optimised
+index** that answers "where is X?" in microseconds instead of milliseconds.


### PR DESCRIPTION
#14 
- Adds crdt-core/src/index/ - a Vec-backed
  augmented B+ tree (PositionIndex) that maintains a
  mapping from CRDT block IDs to visible document
  positions in O(log n).
  - position_of(id) and find_at_position(pos) replace
   the previous O(n) linked-list walks used by
  visible_position_of and
  get_block_and_offset_by_position.
  - The tree is kept in sync with the document at
  every mutation chokepoint (integrate, split_block,
  mark_block_deleted, collect_garbage). A debug-build
   oracle (assert_index_matches_linked_list) fires
  after every mutation to verify the two structures
  agree.
  - Module is S.O.L.I.D-decomposed: structs/ holds
  data-only types, operation files (mutate, find,
  split, propagate, build, descend, storage_ops) each
   own a single concern, and constants.rs holds the
  branching-factor tunables (4 in debug, 32/16 in
  release).
  - 16 targeted index unit tests + 7
  two-client/snapshot reproducer tests for the
  reported cursor-on-line-2 regression; all 92 tests
  pass.