### PR TITLE
fix windows crlf desync on mid-line edits

### DIFF
--- a/tauri-app/src-tauri/src/persistence/commands.rs
+++ b/tauri-app/src-tauri/src/persistence/commands.rs
@@ -20,6 +20,21 @@ pub async fn save_document(
     Ok(())
 }
 
+fn rebuild_if_crlf(doc: Document) -> Result<(Document, String), String> {
+    let text = doc.get_text();
+    if !text.contains('\r') {
+        return Ok((doc, text));
+    }
+    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    let mut fresh = Document::new(doc.client_id);
+    if !normalized.is_empty() {
+        fresh
+            .local_insert(0, &normalized)
+            .map_err(|e| format!("failed to normalize legacy document: {e}"))?;
+    }
+    Ok((fresh, normalized))
+}
+
 #[tauri::command]
 pub async fn load_document(
     app: AppHandle,
@@ -27,10 +42,10 @@ pub async fn load_document(
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let loaded = persistence::load_named(&app, &name).map_err(|e| e.to_string())?;
-    let text = loaded.get_text();
+    let (doc, text) = rebuild_if_crlf(loaded)?;
 
     request(&state.doc_tx, |reply| DocOp::DocumentReplace {
-        doc: Box::new(loaded),
+        doc: Box::new(doc),
         reply,
     })
     .await?;
@@ -64,7 +79,7 @@ pub async fn fork_document(
     fork_snapshot.pending_delete_sets.clear();
 
     let forked = Document::from_snapshot(fork_snapshot);
-    let text = forked.get_text();
+    let (forked, text) = rebuild_if_crlf(forked)?;
 
     persistence::save_named(&app, &new_name, &forked).map_err(|e| e.to_string())?;
 
@@ -101,6 +116,38 @@ pub fn get_current_document_name(state: State<'_, AppState>) -> Result<Option<St
 #[tauri::command]
 pub fn save_text_file(path: String, content: String) -> Result<(), String> {
     fs::write(&path, &content).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rebuild_if_crlf;
+    use crdt_core::types::ClientId;
+    use crdt_core::Document;
+
+    #[test]
+    fn rebuild_if_crlf_keeps_lf_document_intact() {
+        let mut doc = Document::new(ClientId::new(7));
+        doc.local_insert(0, "line one\nline two").unwrap();
+        let original_sv = doc.state_vector.clone();
+
+        let (doc, text) = rebuild_if_crlf(doc).unwrap();
+
+        assert_eq!(text, "line one\nline two");
+        assert_eq!(doc.get_text(), "line one\nline two");
+        assert_eq!(doc.state_vector, original_sv);
+    }
+
+    #[test]
+    fn rebuild_if_crlf_normalizes_legacy_crlf_document() {
+        let mut doc = Document::new(ClientId::new(7));
+        doc.local_insert(0, "line one\r\nline two\rend").unwrap();
+
+        let (doc, text) = rebuild_if_crlf(doc).unwrap();
+
+        assert_eq!(text, "line one\nline two\nend");
+        assert_eq!(doc.get_text(), "line one\nline two\nend");
+        assert_eq!(doc.client_id, ClientId::new(7));
+    }
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/state/document/commands.rs
+++ b/tauri-app/src-tauri/src/state/document/commands.rs
@@ -9,6 +9,17 @@ use crate::state::document::client::request_fallible;
 use crate::state::document::types::DocOp;
 use crate::state::ws_state::WsState;
 
+/// The CRDT must never contain `\r`: positions on the wire are offsets into
+/// LF-only text, so a stray `\r\n` would shift every later position by one
+/// per newline. The frontend already normalizes; this is the final guard.
+fn normalize_to_lf(content: String) -> String {
+    if content.contains('\r') {
+        content.replace("\r\n", "\n").replace('\r', "\n")
+    } else {
+        content
+    }
+}
+
 #[tauri::command]
 pub async fn insert(
     state: State<'_, AppState>,
@@ -17,6 +28,7 @@ pub async fn insert(
     content: String,
     base_seq: u64,
 ) -> Result<(), String> {
+    let content = normalize_to_lf(content);
     debug!(
         "crdt insert request: position={}, content_len={}, base_seq={}",
         position,
@@ -87,6 +99,7 @@ pub async fn replace(
     content: String,
     base_seq: u64,
 ) -> Result<(), String> {
+    let content = normalize_to_lf(content);
     debug!(
         "crdt replace request: position={}, delete_length={}, content_len={}, base_seq={}",
         position,
@@ -122,6 +135,22 @@ pub async fn replace(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_to_lf;
+
+    #[test]
+    fn normalize_to_lf_converts_crlf_and_bare_cr() {
+        assert_eq!(normalize_to_lf("a\r\nb\rc\nd".into()), "a\nb\nc\nd");
+    }
+
+    #[test]
+    fn normalize_to_lf_leaves_lf_only_text_untouched() {
+        assert_eq!(normalize_to_lf("a\nb\nc".into()), "a\nb\nc");
+        assert_eq!(normalize_to_lf(String::new()), "");
+    }
 }
 
 #[cfg(debug_assertions)]

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -13,6 +13,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useRemoteChangeListener } from "./remoteChangeListener";
 import { useSnapshotListener } from "./snapshotListener";
 import { createEnqueueOp, createIpcSenders } from "./opQueue";
+import { normalizeToLF, forceModelLF } from "./eol";
 import {
   UsernameGate,
   overlayStyle,
@@ -267,7 +268,9 @@ function installPlainTextPasteHandler(
     event.preventDefault();
     event.stopPropagation();
 
-    const text = event.clipboardData?.getData("text/plain") ?? "";
+    const text = normalizeToLF(
+      event.clipboardData?.getData("text/plain") ?? "",
+    );
 
     if (text) {
       editorInstance.focus();
@@ -278,7 +281,9 @@ function installPlainTextPasteHandler(
     void navigator.clipboard.readText().then((clipText) => {
       if (!clipText) return;
       editorInstance.focus();
-      editorInstance.trigger("plain-text-paste", "type", { text: clipText });
+      editorInstance.trigger("plain-text-paste", "type", {
+        text: normalizeToLF(clipText),
+      });
     });
   };
 
@@ -313,6 +318,7 @@ function AppContent({ username }: AppContentProps) {
     if (ed) {
       isApplyingRemote.current = true;
       ed.setValue(text);
+      forceModelLF(ed, monacoRef.current);
       isApplyingRemote.current = false;
       shadowTextRef.current = text;
     }
@@ -462,7 +468,11 @@ function AppContent({ username }: AppContentProps) {
   const resetDocAndEditor = useCallback(async () => {
     await invoke("reset_document");
     isApplyingRemote.current = true;
-    editorRef.current?.setValue("");
+    const ed = editorRef.current;
+    if (ed) {
+      ed.setValue("");
+      forceModelLF(ed, monacoRef.current);
+    }
     isApplyingRemote.current = false;
     shadowTextRef.current = "";
   }, []);
@@ -803,9 +813,7 @@ function AppContent({ username }: AppContentProps) {
     // Force LF on all platforms. Without this, Windows/WebView2 defaults to
     // CRLF which makes every newline 2 bytes in the model, shifting all offsets
     // relative to Linux/macOS peers and causing divergence.
-    editorInstance
-      .getModel()
-      ?.setEOL(monacoInstance.editor.EndOfLineSequence.LF);
+    forceModelLF(editorInstance, monacoInstance);
 
     installPlainTextPasteHandler(editorInstance);
     setStatus("editor ready");
@@ -823,7 +831,7 @@ function AppContent({ username }: AppContentProps) {
         const changes = event.changes.map((c) => ({
           offset: c.rangeOffset,
           deleteLen: c.rangeLength,
-          text: c.text,
+          text: normalizeToLF(c.text),
         }));
 
         // Revert Monaco to the shadow text — the backend will emit events

--- a/tauri-app/src/eol.ts
+++ b/tauri-app/src/eol.ts
@@ -1,0 +1,19 @@
+import type { editor } from "monaco-editor";
+import type { Monaco } from "@monaco-editor/react";
+
+// The CRDT stores LF-only text, and every position exchanged with the backend
+// is an offset into that text. Monaco must count newlines the same way, so all
+// text entering the pipeline is normalized to "\n" and the model EOL is pinned
+// to LF everywhere.
+
+export function normalizeToLF(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function forceModelLF(
+  ed: editor.IStandaloneCodeEditor,
+  mn: Monaco | null,
+): void {
+  if (!mn) return;
+  ed.getModel()?.setEOL(mn.editor.EndOfLineSequence.LF);
+}


### PR DESCRIPTION
enforce an lf-only invariant end to end. add eol.ts (normalizeToLF + forceModelLF) 
and re-assert lf after every setValue; normalize paste + outbound text. 
backstop in the rust insert/replace commands so \r can never reach the crdt, and rebuild old crlf docs on load/fork.