### PR TITLE
add per-peer write permissions with host-controlled grant/revoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,15 @@ There is a binary wire framing **and** a JSON protocol envelope. They are not th
   - `0x04` = gc-commit (bitcode-encoded `DeleteSet`; host → all peers — see Garbage collection)
   - `0x05` = membership (fixed 10-byte `[0x05][event][client_id u64 BE]`, **not** bitcode; gateway → all clients)
   - `0x06` = sv-report (bitcode-encoded `(ClientId, Vec<(ClientId,u64)>)`; peer → all, host consumes)
+  - `0x07` = permission (fixed 10-byte `[0x07][can_write 0|1][client_id u64 BE]`; host → gateway as a change request, gateway → all clients as the authoritative echo — see Permissions)
+  - `0x08` = peer-info (`[0x08][flags][client_id u64 BE][len u8][username]`, flags bit0 = host / bit1 = can-write; gateway-authored only — sent to a joiner for every current member incl. itself, and to existing members when someone joins)
 - **JSON envelope** (`gateway/internal/protocol/protocol.go`) documents a higher-level `{type, room, client_id, seq, payload}` message intended for sync/peer-list semantics. Treat this file as the protocol spec; the gateway today operates on raw binary frames (snapshot vs op detection) and does not currently parse the JSON envelope.
 
 The gateway's room (`gateway/internal/room/room.go`) is a stateless relay: it stores neither a snapshot nor an ops log. On join it calls `ReplayTo`, which sends the host a `snapshot-request` control frame and forwards the host's fresh snapshot response to the joiner; all other frames are broadcast to peers (sender excluded). The room also emits `membership` frames (`0x05`) on join/leave so the host can track membership for GC. `gc-commit`/`sv-report` frames are broadcast like ops (the gateway never decodes them).
+
+### Permissions
+
+Guests join read-only unless the host opted into `default_can_write` (a WS query param on the host's own connection, chosen via the "Guests can edit" toggle); the host can then grant/revoke write access per peer. The gateway is the authority: each `client.Client` carries `Role` (first joiner = host) and an atomic `canWrite`; the room drops op frames from read-only senders and handles inbound `0x07` frames (host-only, host target immutable) by flipping the target's flag and echoing the frame to everyone. Rosters are seeded with `0x08` peer-info frames at join. On the Tauri side, `state/roster.rs` owns the peer list and applies permission/peer-info/membership frames (the ws receiver only routes); a guest's own permission lives as `WriteAccess` inside `AppRole::Guest` and gates the `insert`/`delete`/`replace` commands, with Monaco's `readOnly` mirroring it via `session://can-write`. Beware: Monaco silently drops editor-level `executeEdits` on a read-only editor, so remote changes are applied through `executeRemoteEdit` in `remoteChangeListener.ts`, which lifts the flag around the edit. The peers UI is `components/PeersPanel.tsx` fed by `session://room-state`; client ids cross the JS boundary as strings (u64 > 2^53).
 
 ### Garbage collection
 

--- a/crdt-core/src/lib.rs
+++ b/crdt-core/src/lib.rs
@@ -13,7 +13,9 @@ pub use index::{FindResult, PositionIndex};
 pub use snapshot::{Snapshot, SnapshotBlock, SnapshotError};
 pub use wire::{
     GcCommit, MembershipEvent, MembershipFrame, OP_PREFIX, OpMessage, PREFIX_GC_COMMIT,
-    PREFIX_MEMBERSHIP, PREFIX_SV_REPORT, SNAPSHOT_PREFIX, WireBlock, WireError, decode_gc_commit,
-    decode_membership, decode_op, decode_snapshot, decode_sv_report, encode_gc_commit,
-    encode_membership, encode_op, encode_snapshot, encode_sv_report,
+    PREFIX_MEMBERSHIP, PREFIX_PEER_INFO, PREFIX_PERMISSION, PREFIX_SV_REPORT, PeerInfoFrame,
+    PermissionFrame, SNAPSHOT_PREFIX, WireBlock, WireError, decode_gc_commit, decode_membership,
+    decode_op, decode_peer_info, decode_permission, decode_snapshot, decode_sv_report,
+    encode_gc_commit, encode_membership, encode_op, encode_peer_info, encode_permission,
+    encode_snapshot, encode_sv_report,
 };

--- a/crdt-core/src/wire.rs
+++ b/crdt-core/src/wire.rs
@@ -15,9 +15,14 @@ pub const CONTROL_SNAPSHOT_REQUEST: u8 = 0x02;
 pub const PREFIX_GC_COMMIT: u8 = 0x04;
 pub const PREFIX_MEMBERSHIP: u8 = 0x05;
 pub const PREFIX_SV_REPORT: u8 = 0x06;
+pub const PREFIX_PERMISSION: u8 = 0x07;
+pub const PREFIX_PEER_INFO: u8 = 0x08;
 
 pub const PEER_JOINED: u8 = 0x01;
 pub const PEER_LEFT: u8 = 0x02;
+
+pub const PEER_FLAG_HOST: u8 = 0x01;
+pub const PEER_FLAG_CAN_WRITE: u8 = 0x02;
 
 #[derive(Debug, Clone, PartialEq, Eq, bitcode::Encode, bitcode::Decode)]
 pub struct WireBlock {
@@ -63,6 +68,20 @@ pub struct MembershipFrame {
     pub event: MembershipEvent,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PermissionFrame {
+    pub client_id: ClientId,
+    pub can_write: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerInfoFrame {
+    pub client_id: ClientId,
+    pub is_host: bool,
+    pub can_write: bool,
+    pub username: String,
+}
+
 #[derive(Debug)]
 pub enum WireError {
     EmptyFrame,
@@ -73,6 +92,10 @@ pub enum WireError {
     NotAMember,
     NotAnSvReport,
     MalformedMembership,
+    NotAPermission,
+    MalformedPermission,
+    NotAPeerInfo,
+    MalformedPeerInfo,
     Decode(bitcode::Error),
     SnapshotDecode(SnapshotError),
 }
@@ -101,6 +124,18 @@ impl fmt::Display for WireError {
             }
             WireError::MalformedMembership => {
                 write!(f, "membership frame has an invalid layout")
+            }
+            WireError::NotAPermission => {
+                write!(f, "wire frame is not a permission frame")
+            }
+            WireError::MalformedPermission => {
+                write!(f, "permission frame has an invalid layout")
+            }
+            WireError::NotAPeerInfo => {
+                write!(f, "wire frame is not a peer-info frame")
+            }
+            WireError::MalformedPeerInfo => {
+                write!(f, "peer-info frame has an invalid layout")
             }
             WireError::Decode(e) => write!(f, "bitcode decode failed: {e}"),
             WireError::SnapshotDecode(e) => write!(f, "snapshot decode failed: {e}"),
@@ -236,6 +271,76 @@ pub fn decode_membership(frame: &[u8]) -> Result<MembershipFrame, WireError> {
     Ok(MembershipFrame {
         client_id: ClientId::new(u64::from_be_bytes(client_bytes)),
         event,
+    })
+}
+
+pub fn encode_permission(frame: &PermissionFrame) -> Vec<u8> {
+    let mut out = Vec::with_capacity(10);
+    out.push(PREFIX_PERMISSION);
+    out.push(u8::from(frame.can_write));
+    out.extend_from_slice(&frame.client_id.value.to_be_bytes());
+    out
+}
+
+pub fn decode_permission(frame: &[u8]) -> Result<PermissionFrame, WireError> {
+    let (&prefix, payload) = frame.split_first().ok_or(WireError::EmptyFrame)?;
+    if prefix != PREFIX_PERMISSION {
+        return Err(WireError::NotAPermission);
+    }
+    if payload.len() != 9 || payload[0] > 1 {
+        return Err(WireError::MalformedPermission);
+    }
+    let mut client_bytes = [0u8; 8];
+    client_bytes.copy_from_slice(&payload[1..9]);
+    Ok(PermissionFrame {
+        client_id: ClientId::new(u64::from_be_bytes(client_bytes)),
+        can_write: payload[0] == 1,
+    })
+}
+
+pub fn encode_peer_info(frame: &PeerInfoFrame) -> Vec<u8> {
+    let username = frame.username.as_bytes();
+    debug_assert!(username.len() <= u8::MAX as usize);
+    let mut flags = 0u8;
+    if frame.is_host {
+        flags |= PEER_FLAG_HOST;
+    }
+    if frame.can_write {
+        flags |= PEER_FLAG_CAN_WRITE;
+    }
+    let mut out = Vec::with_capacity(11 + username.len());
+    out.push(PREFIX_PEER_INFO);
+    out.push(flags);
+    out.extend_from_slice(&frame.client_id.value.to_be_bytes());
+    out.push(username.len() as u8);
+    out.extend_from_slice(username);
+    out
+}
+
+pub fn decode_peer_info(frame: &[u8]) -> Result<PeerInfoFrame, WireError> {
+    let (&prefix, payload) = frame.split_first().ok_or(WireError::EmptyFrame)?;
+    if prefix != PREFIX_PEER_INFO {
+        return Err(WireError::NotAPeerInfo);
+    }
+    if payload.len() < 10 {
+        return Err(WireError::MalformedPeerInfo);
+    }
+    let flags = payload[0];
+    let mut client_bytes = [0u8; 8];
+    client_bytes.copy_from_slice(&payload[1..9]);
+    let username_len = payload[9] as usize;
+    let username_bytes = &payload[10..];
+    if username_bytes.len() != username_len {
+        return Err(WireError::MalformedPeerInfo);
+    }
+    let username = std::str::from_utf8(username_bytes)
+        .map_err(|_| WireError::MalformedPeerInfo)?
+        .to_string();
+    Ok(PeerInfoFrame {
+        client_id: ClientId::new(u64::from_be_bytes(client_bytes)),
+        is_host: flags & PEER_FLAG_HOST != 0,
+        can_write: flags & PEER_FLAG_CAN_WRITE != 0,
+        username,
     })
 }
 

--- a/crdt-core/src/wire/protocol_drift_tests.rs
+++ b/crdt-core/src/wire/protocol_drift_tests.rs
@@ -1,7 +1,8 @@
 use super::{
     CONTROL_SESSION_ENDED, CONTROL_SNAPSHOT_REQUEST, MembershipEvent, MembershipFrame, OP_PREFIX,
-    PEER_JOINED, PEER_LEFT, PREFIX_CONTROL, PREFIX_GC_COMMIT, PREFIX_MEMBERSHIP, PREFIX_SV_REPORT,
-    SNAPSHOT_PREFIX, encode_membership,
+    PEER_FLAG_CAN_WRITE, PEER_FLAG_HOST, PEER_JOINED, PEER_LEFT, PREFIX_CONTROL, PREFIX_GC_COMMIT,
+    PREFIX_MEMBERSHIP, PREFIX_PEER_INFO, PREFIX_PERMISSION, PREFIX_SV_REPORT, PeerInfoFrame,
+    PermissionFrame, SNAPSHOT_PREFIX, encode_membership, encode_peer_info, encode_permission,
 };
 use crate::types::ClientId;
 
@@ -17,8 +18,12 @@ fn prefix_constants_match_go_mirror() {
     const GO_PREFIX_GC_COMMIT: u8 = 0x04;
     const GO_PREFIX_MEMBERSHIP: u8 = 0x05;
     const GO_PREFIX_SV_REPORT: u8 = 0x06;
+    const GO_PREFIX_PERMISSION: u8 = 0x07;
+    const GO_PREFIX_PEER_INFO: u8 = 0x08;
     const GO_MEMBERSHIP_JOINED: u8 = 0x01;
     const GO_MEMBERSHIP_LEFT: u8 = 0x02;
+    const GO_PEER_FLAG_HOST: u8 = 0x01;
+    const GO_PEER_FLAG_CAN_WRITE: u8 = 0x02;
 
     assert_eq!(
         OP_PREFIX, GO_PREFIX_OP,
@@ -60,6 +65,22 @@ fn prefix_constants_match_go_mirror() {
         PEER_LEFT, GO_MEMBERSHIP_LEFT,
         "MEMBERSHIP_LEFT drifted from gateway/internal/wire::MembershipLeft"
     );
+    assert_eq!(
+        PREFIX_PERMISSION, GO_PREFIX_PERMISSION,
+        "PREFIX_PERMISSION drifted from gateway/internal/wire::PrefixPermission"
+    );
+    assert_eq!(
+        PREFIX_PEER_INFO, GO_PREFIX_PEER_INFO,
+        "PREFIX_PEER_INFO drifted from gateway/internal/wire::PrefixPeerInfo"
+    );
+    assert_eq!(
+        PEER_FLAG_HOST, GO_PEER_FLAG_HOST,
+        "PEER_FLAG_HOST drifted from gateway/internal/wire::PeerFlagHost"
+    );
+    assert_eq!(
+        PEER_FLAG_CAN_WRITE, GO_PEER_FLAG_CAN_WRITE,
+        "PEER_FLAG_CAN_WRITE drifted from gateway/internal/wire::PeerFlagCanWrite"
+    );
 }
 
 #[test]
@@ -84,5 +105,60 @@ fn presence_layout_matches_go_mirror() {
         encode_membership(&frame),
         expected,
         "Membership frame layout drifted from gateway/internal/wire::EncodeMembershipFrame"
+    );
+}
+
+#[test]
+fn permission_layout_matches_go_mirror() {
+    let frame = PermissionFrame {
+        client_id: ClientId::new(0x0102_0304_0506_0708),
+        can_write: true,
+    };
+    let expected = vec![
+        PREFIX_PERMISSION,
+        0x01,
+        0x01,
+        0x02,
+        0x03,
+        0x04,
+        0x05,
+        0x06,
+        0x07,
+        0x08,
+    ];
+    assert_eq!(
+        encode_permission(&frame),
+        expected,
+        "Permission frame layout drifted from gateway/internal/wire::EncodePermissionFrame"
+    );
+}
+
+#[test]
+fn peer_info_layout_matches_go_mirror() {
+    let frame = PeerInfoFrame {
+        client_id: ClientId::new(0x0102_0304_0506_0708),
+        is_host: true,
+        can_write: true,
+        username: "ab".to_string(),
+    };
+    let expected = vec![
+        PREFIX_PEER_INFO,
+        PEER_FLAG_HOST | PEER_FLAG_CAN_WRITE,
+        0x01,
+        0x02,
+        0x03,
+        0x04,
+        0x05,
+        0x06,
+        0x07,
+        0x08,
+        0x02,
+        b'a',
+        b'b',
+    ];
+    assert_eq!(
+        encode_peer_info(&frame),
+        expected,
+        "Peer-info frame layout drifted from gateway/internal/wire::EncodePeerInfoFrame"
     );
 }

--- a/crdt-core/src/wire/tests.rs
+++ b/crdt-core/src/wire/tests.rs
@@ -240,3 +240,115 @@ fn decode_membership_rejects_unknown_event() {
         Err(WireError::MalformedMembership)
     ));
 }
+
+#[test]
+fn permission_round_trips_grant_and_revoke() {
+    for can_write in [true, false] {
+        let frame = PermissionFrame {
+            client_id: ClientId::new(0x0102_0304_0506_0708),
+            can_write,
+        };
+        let bytes = encode_permission(&frame);
+        assert_eq!(bytes.len(), 10);
+        assert_eq!(bytes[0], PREFIX_PERMISSION);
+        assert_eq!(decode_permission(&bytes).expect("decode"), frame);
+    }
+}
+
+#[test]
+fn decode_permission_rejects_wrong_prefix() {
+    let frame = vec![OP_PREFIX, 1, 0, 0, 0, 0, 0, 0, 0, 1];
+    assert!(matches!(
+        decode_permission(&frame),
+        Err(WireError::NotAPermission)
+    ));
+}
+
+#[test]
+fn decode_permission_rejects_bad_length() {
+    let frame = vec![PREFIX_PERMISSION, 1, 0, 0];
+    assert!(matches!(
+        decode_permission(&frame),
+        Err(WireError::MalformedPermission)
+    ));
+}
+
+#[test]
+fn decode_permission_rejects_invalid_flag() {
+    let frame = vec![PREFIX_PERMISSION, 0x02, 0, 0, 0, 0, 0, 0, 0, 1];
+    assert!(matches!(
+        decode_permission(&frame),
+        Err(WireError::MalformedPermission)
+    ));
+}
+
+#[test]
+fn peer_info_round_trips_all_flag_combinations() {
+    for (is_host, can_write) in [(false, false), (false, true), (true, false), (true, true)] {
+        let frame = PeerInfoFrame {
+            client_id: ClientId::new(0x0102_0304_0506_0708),
+            is_host,
+            can_write,
+            username: "alice".to_string(),
+        };
+        let bytes = encode_peer_info(&frame);
+        assert_eq!(bytes[0], PREFIX_PEER_INFO);
+        assert_eq!(decode_peer_info(&bytes).expect("decode"), frame);
+    }
+}
+
+#[test]
+fn peer_info_round_trips_empty_and_unicode_username() {
+    for username in ["", "ალისა 🦀"] {
+        let frame = PeerInfoFrame {
+            client_id: ClientId::new(7),
+            is_host: false,
+            can_write: true,
+            username: username.to_string(),
+        };
+        let bytes = encode_peer_info(&frame);
+        assert_eq!(decode_peer_info(&bytes).expect("decode"), frame);
+    }
+}
+
+#[test]
+fn decode_peer_info_rejects_wrong_prefix() {
+    let frame = vec![OP_PREFIX, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0];
+    assert!(matches!(
+        decode_peer_info(&frame),
+        Err(WireError::NotAPeerInfo)
+    ));
+}
+
+#[test]
+fn decode_peer_info_rejects_truncated_frame() {
+    let frame = vec![PREFIX_PEER_INFO, 0, 0, 0];
+    assert!(matches!(
+        decode_peer_info(&frame),
+        Err(WireError::MalformedPeerInfo)
+    ));
+}
+
+#[test]
+fn decode_peer_info_rejects_username_length_mismatch() {
+    let mut frame = vec![PREFIX_PEER_INFO, 0];
+    frame.extend_from_slice(&7u64.to_be_bytes());
+    frame.push(5);
+    frame.extend_from_slice(b"ab");
+    assert!(matches!(
+        decode_peer_info(&frame),
+        Err(WireError::MalformedPeerInfo)
+    ));
+}
+
+#[test]
+fn decode_peer_info_rejects_invalid_utf8_username() {
+    let mut frame = vec![PREFIX_PEER_INFO, 0];
+    frame.extend_from_slice(&7u64.to_be_bytes());
+    frame.push(2);
+    frame.extend_from_slice(&[0xFF, 0xFE]);
+    assert!(matches!(
+        decode_peer_info(&frame),
+        Err(WireError::MalformedPeerInfo)
+    ));
+}

--- a/gateway/internal/client/client.go
+++ b/gateway/internal/client/client.go
@@ -10,23 +10,34 @@ import (
 
 const sendBufferSize = 256
 
+type Role int32
+
+const (
+	RoleGuest Role = iota
+	RoleHost
+)
+
 type Client struct {
-	ID     string
-	RoomID string
-	conn   *websocket.Conn
-	send   chan []byte
-	closed atomic.Bool
-	host   atomic.Bool
+	ID       string
+	RoomID   string
+	Username string
+	HostDefaultCanWrite bool
+	conn                *websocket.Conn
+	send                chan []byte
+	closed              atomic.Bool
+	role                atomic.Int32
+	canWrite            atomic.Bool
 }
 
-func New(id, roomID string, conn *websocket.Conn) *Client {
+func New(id, roomID, username string, conn *websocket.Conn) *Client {
 	c := &Client{
-		ID:     id,
-		RoomID: roomID,
-		conn:   conn,
-		send:   make(chan []byte, sendBufferSize),
+		ID:       id,
+		RoomID:   roomID,
+		Username: username,
+		conn:     conn,
+		send:     make(chan []byte, sendBufferSize),
 	}
-	slog.Info("client created", "room_id", roomID, "client_id", id, "send_buffer_size", sendBufferSize)
+	slog.Info("client created", "room_id", roomID, "client_id", id, "username", username, "send_buffer_size", sendBufferSize)
 	return c
 }
 
@@ -35,16 +46,24 @@ func (c *Client) CloseSend() {
 	close(c.send)
 }
 
-func (c *Client) MarkHost() {
-	c.host.Store(true)
+func (c *Client) SetRole(r Role) {
+	c.role.Store(int32(r))
 }
 
-func (c *Client) ClearHost() {
-	c.host.Store(false)
+func (c *Client) Role() Role {
+	return Role(c.role.Load())
 }
 
 func (c *Client) IsHost() bool {
-	return c != nil && c.host.Load()
+	return c != nil && c.Role() == RoleHost
+}
+
+func (c *Client) SetCanWrite(v bool) {
+	c.canWrite.Store(v)
+}
+
+func (c *Client) CanWrite() bool {
+	return c != nil && c.canWrite.Load()
 }
 
 // returns false without blocking if the send buffer is full

--- a/gateway/internal/client/client.go
+++ b/gateway/internal/client/client.go
@@ -18,9 +18,9 @@ const (
 )
 
 type Client struct {
-	ID       string
-	RoomID   string
-	Username string
+	ID                  string
+	RoomID              string
+	Username            string
 	HostDefaultCanWrite bool
 	conn                *websocket.Conn
 	send                chan []byte

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -135,9 +135,9 @@ func (h *Hub) unregister(c *client.Client, r *room.Room) {
 }
 
 type wsParams struct {
-	roomID   string
-	clientID string
-	username string
+	roomID          string
+	clientID        string
+	username        string
 	defaultCanWrite bool
 }
 

--- a/gateway/internal/hub/hub.go
+++ b/gateway/internal/hub/hub.go
@@ -6,11 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/coder/websocket"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
+
+	"github.com/coder/websocket"
 
 	"gateway/internal/client"
 	gatewaymetrics "gateway/internal/metrics"
@@ -131,20 +134,44 @@ func (h *Hub) unregister(c *client.Client, r *room.Room) {
 	r.Leave(c, func() { h.discardIfStale(r.ID, r) })
 }
 
-func readWSParams(w http.ResponseWriter, r *http.Request) (roomID, clientID string, ok bool) {
-	roomID = r.URL.Query().Get("room")
+type wsParams struct {
+	roomID   string
+	clientID string
+	username string
+	defaultCanWrite bool
+}
+
+func readWSParams(w http.ResponseWriter, r *http.Request) (wsParams, bool) {
+	roomID := r.URL.Query().Get("room")
 	if roomID == "" {
 		slog.Warn("websocket rejected: missing room parameter")
 		http.Error(w, "missing ?room= parameter", http.StatusBadRequest)
-		return "", "", false
+		return wsParams{}, false
 	}
-	clientID = r.URL.Query().Get("client_id")
+	clientID := r.URL.Query().Get("client_id")
 	if clientID == "" {
 		slog.Warn("websocket rejected: missing client_id parameter", "room_id", roomID)
 		http.Error(w, "missing ?client_id= parameter", http.StatusBadRequest)
-		return "", "", false
+		return wsParams{}, false
 	}
-	return roomID, clientID, true
+	return wsParams{
+		roomID:          roomID,
+		clientID:        clientID,
+		username:        sanitizeUsername(r.URL.Query().Get("username")),
+		defaultCanWrite: r.URL.Query().Get("default_can_write") == "true",
+	}, true
+}
+
+func sanitizeUsername(raw string) string {
+	valid := strings.ToValidUTF8(raw, "")
+	if len(valid) <= wire.MaxUsernameBytes {
+		return valid
+	}
+	cut := wire.MaxUsernameBytes
+	for cut > 0 && !utf8.RuneStart(valid[cut]) {
+		cut--
+	}
+	return valid[:cut]
 }
 
 func (h *Hub) dispatchFrame(rm *room.Room, sender *client.Client, raw []byte) {
@@ -215,10 +242,11 @@ func (h *Hub) HandleEndSession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
-	roomID, clientID, ok := readWSParams(w, r)
+	params, ok := readWSParams(w, r)
 	if !ok {
 		return
 	}
+	roomID, clientID := params.roomID, params.clientID
 
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
@@ -230,7 +258,8 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 	conn.SetReadLimit(maxInboundMessageBytes)
 	slog.Info("websocket upgraded", "room_id", roomID, "client_id", clientID)
 
-	c := client.New(clientID, roomID, conn)
+	c := client.New(clientID, roomID, params.username, conn)
+	c.HostDefaultCanWrite = params.defaultCanWrite
 	rm, err := h.register(c)
 	if err != nil {
 		if errors.Is(err, room.ErrDuplicateClientID) {

--- a/gateway/internal/hub/hub_test.go
+++ b/gateway/internal/hub/hub_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/coder/websocket"
 
@@ -342,6 +343,107 @@ func TestHub_FanOut_ThreeClients(t *testing.T) {
 	_, _, err := a.Read(noEchoCtx)
 	if err == nil {
 		t.Fatal("mate received echo")
+	}
+}
+
+func readFrameWithPrefix(t *testing.T, conn *websocket.Conn, prefix byte) []byte {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, data, err := conn.Read(ctx)
+		cancel()
+		if err != nil {
+			t.Fatalf("read while waiting for prefix %#x: %v", prefix, err)
+		}
+		if len(data) > 0 && data[0] == prefix {
+			return data
+		}
+	}
+	t.Fatalf("no frame with prefix %#x arrived", prefix)
+	return nil
+}
+
+func answerSnapshotRequestSkippingRoster(t *testing.T, host *websocket.Conn) {
+	t.Helper()
+	request := readFrameWithPrefix(t, host, wire.PrefixControl)
+	if len(request) != 2 || request[1] != wire.ControlSnapshotRequest {
+		t.Fatalf("control frame = %v, want snapshot request", request)
+	}
+	if err := host.Write(context.Background(), websocket.MessageBinary, []byte{wire.PrefixSnapshot, 0xAA}); err != nil {
+		t.Fatalf("host snapshot response write: %v", err)
+	}
+}
+
+func TestHub_ReadOnlyGuestPermissionLifecycle(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	host := dial(t, wsURL(srv.URL, "perm", "1"))
+	defer host.Close(websocket.StatusNormalClosure, "")
+	guest := dial(t, wsURL(srv.URL, "perm", "2")+"&username=guestname")
+	defer guest.Close(websocket.StatusNormalClosure, "")
+	answerSnapshotRequestSkippingRoster(t, host)
+	_ = readFrameWithPrefix(t, guest, wire.PrefixSnapshot)
+
+	blocked := wire.EncodeOpFrame([]byte("blocked"))
+	if err := guest.Write(context.Background(), websocket.MessageBinary, blocked); err != nil {
+		t.Fatalf("guest write: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	grant := wire.EncodePermissionFrame(2, true)
+	if err := host.Write(context.Background(), websocket.MessageBinary, grant); err != nil {
+		t.Fatalf("host write grant: %v", err)
+	}
+	if got := readFrameWithPrefix(t, guest, wire.PrefixPermission); !bytes.Equal(got, grant) {
+		t.Fatalf("guest permission echo = %x, want %x", got, grant)
+	}
+	if got := readFrameWithPrefix(t, host, wire.PrefixPermission); !bytes.Equal(got, grant) {
+		t.Fatalf("host permission echo = %x, want %x", got, grant)
+	}
+
+	allowed := wire.EncodeOpFrame([]byte("allowed"))
+	if err := guest.Write(context.Background(), websocket.MessageBinary, allowed); err != nil {
+		t.Fatalf("guest write after grant: %v", err)
+	}
+	if got := readFrameWithPrefix(t, host, wire.PrefixOp); !bytes.Equal(got, allowed) {
+		t.Fatalf("host op = %x, want %x", got, allowed)
+	}
+}
+
+func TestHub_DefaultCanWriteParamGrantsGuests(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	host := dial(t, wsURL(srv.URL, "perm-default", "1")+"&default_can_write=true")
+	defer host.Close(websocket.StatusNormalClosure, "")
+	guest := dial(t, wsURL(srv.URL, "perm-default", "2"))
+	defer guest.Close(websocket.StatusNormalClosure, "")
+	answerSnapshotRequestSkippingRoster(t, host)
+	_ = readFrameWithPrefix(t, guest, wire.PrefixSnapshot)
+
+	op := wire.EncodeOpFrame([]byte("immediate"))
+	if err := guest.Write(context.Background(), websocket.MessageBinary, op); err != nil {
+		t.Fatalf("guest write: %v", err)
+	}
+	if got := readFrameWithPrefix(t, host, wire.PrefixOp); !bytes.Equal(got, op) {
+		t.Fatalf("host op = %x, want %x", got, op)
+	}
+}
+
+func TestSanitizeUsername(t *testing.T) {
+	if got := sanitizeUsername("alice"); got != "alice" {
+		t.Fatalf("sanitizeUsername(alice) = %q", got)
+	}
+	if got := sanitizeUsername(string([]byte{0xFF, 'a', 0xFE})); got != "a" {
+		t.Fatalf("sanitizeUsername(invalid utf8) = %q, want %q", got, "a")
+	}
+	long := strings.Repeat("é", 200)
+	got := sanitizeUsername(long)
+	if len(got) > wire.MaxUsernameBytes {
+		t.Fatalf("sanitized username is %d bytes, want <= %d", len(got), wire.MaxUsernameBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("sanitized username was cut mid-rune")
 	}
 }
 

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -31,9 +31,10 @@ type Room struct {
 	ID string
 
 	mu      sync.Mutex
-	clients map[*client.Client]struct{}
+	clients map[string]*client.Client
 	closed  bool
 	host    *client.Client
+	defaultCanWrite bool
 
 	snapshotRequests []chan []byte
 
@@ -46,7 +47,7 @@ type Room struct {
 func New(id string, registry *gatewaymetrics.Registry) *Room {
 	return &Room{
 		ID:      id,
-		clients: make(map[*client.Client]struct{}),
+		clients: make(map[string]*client.Client),
 		ops:     make(chan BroadcastMsg, opsBufferSize),
 		done:    make(chan struct{}),
 		metrics: registry,
@@ -60,39 +61,43 @@ func (r *Room) Join(c *client.Client) error {
 		slog.Warn("join rejected: room already closed", "room_id", r.ID, "client_id", c.ID)
 		return ErrRoomClosed
 	}
-	for existing := range r.clients {
-		if existing.ID == c.ID {
-			slog.Warn("join rejected: duplicate client_id", "room_id", r.ID, "client_id", c.ID)
-			return ErrDuplicateClientID
-		}
+	if _, exists := r.clients[c.ID]; exists {
+		slog.Warn("join rejected: duplicate client_id", "room_id", r.ID, "client_id", c.ID)
+		return ErrDuplicateClientID
 	}
-	r.clients[c] = struct{}{}
-	isHost := false
-	if r.host == nil {
+	r.clients[c.ID] = c
+	isHost := r.host == nil
+	if isHost {
 		r.host = c
-		c.MarkHost()
-		isHost = true
-		slog.Info("host client registered", "room_id", r.ID, "client_id", c.ID)
+		c.SetRole(client.RoleHost)
+		c.SetCanWrite(true)
+		r.defaultCanWrite = c.HostDefaultCanWrite
+		slog.Info("host client registered", "room_id", r.ID, "client_id", c.ID, "default_can_write", r.defaultCanWrite)
+	} else {
+		c.SetRole(client.RoleGuest)
+		c.SetCanWrite(r.defaultCanWrite)
 	}
 	r.metrics.ClientJoined(isHost)
 	// Notify existing members (incl. the host) that c joined.
 	r.broadcastMembershipLocked(c.ID, wire.MembershipJoined, c)
-	slog.Info("join accepted", "room_id", r.ID, "client_id", c.ID, "size", len(r.clients))
+	r.sendRosterLocked(c)
+	r.announcePeerLocked(c)
+	slog.Info("join accepted", "room_id", r.ID, "client_id", c.ID, "can_write", c.CanWrite(), "size", len(r.clients))
 	return nil
 }
 
 func (r *Room) Leave(c *client.Client, onEmpty func()) {
 	r.mu.Lock()
-	if _, ok := r.clients[c]; !ok {
+	if current, ok := r.clients[c.ID]; !ok || current != c {
 		slog.Debug("leave ignored: client not present in room", "room_id", r.ID, "client_id", c.ID)
 		r.mu.Unlock()
 		return
 	}
-	delete(r.clients, c)
+	delete(r.clients, c.ID)
 	wasHost := r.host == c
 	if wasHost {
 		r.host = nil
-		c.ClearHost()
+		c.SetRole(client.RoleGuest)
 	}
 	r.metrics.ClientLeft(wasHost)
 	c.CloseSend()
@@ -171,21 +176,67 @@ func (r *Room) Run() {
 			slog.Info("room loop stopped", "room_id", r.ID)
 			return
 		case msg := <-r.ops:
-			if wire.IsSnapshotFrame(msg.Data) {
-				if !r.deliverSnapshotResponse(msg.Sender, msg.Data) {
-					slog.Debug("snapshot frame dropped: no pending snapshot request", "room_id", r.ID, "client_id", msg.Sender.ID, "bytes", len(msg.Data))
-				}
-			} else {
-				r.broadcast(msg)
-			}
+			r.dispatch(msg)
 		}
 	}
+}
+
+func (r *Room) dispatch(msg BroadcastMsg) {
+	switch {
+	case wire.IsSnapshotFrame(msg.Data):
+		if !r.deliverSnapshotResponse(msg.Sender, msg.Data) {
+			slog.Debug("snapshot frame dropped: no pending snapshot request", "room_id", r.ID, "client_id", msg.Sender.ID, "bytes", len(msg.Data))
+		}
+	case wire.IsPermissionFrame(msg.Data):
+		r.handlePermissionChange(msg)
+	default:
+		r.broadcast(msg)
+	}
+}
+
+func (r *Room) handlePermissionChange(msg BroadcastMsg) {
+	if !msg.Sender.IsHost() {
+		slog.Warn("permission change dropped from non-host sender", "room_id", r.ID, "client_id", msg.Sender.ID)
+		return
+	}
+	targetID, canWrite, err := wire.DecodePermissionFrame(msg.Data)
+	if err != nil {
+		slog.Warn("permission change dropped: decode failed", "room_id", r.ID, "error", err)
+		return
+	}
+	target := r.clientByID(strconv.FormatUint(targetID, 10))
+	if target == nil {
+		slog.Warn("permission change dropped: unknown target", "room_id", r.ID, "target_id", targetID)
+		return
+	}
+	if target.IsHost() {
+		slog.Warn("permission change dropped: host permission is immutable", "room_id", r.ID, "target_id", targetID)
+		return
+	}
+	target.SetCanWrite(canWrite)
+	slog.Info("permission updated", "room_id", r.ID, "target_id", targetID, "can_write", canWrite)
+	r.BroadcastAll(msg.Data)
+}
+
+func (r *Room) clientByID(id string) *client.Client {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.clients[id]
 }
 
 func (r *Room) broadcast(msg BroadcastMsg) {
 	if wire.IsGcCommitFrame(msg.Data) && !msg.Sender.IsHost() {
 		slog.Warn(
 			"gc-commit dropped from non-host sender",
+			"room_id", r.ID,
+			"client_id", msg.Sender.ID,
+			"bytes", len(msg.Data),
+		)
+		return
+	}
+	if wire.IsOpFrame(msg.Data) && !msg.Sender.CanWrite() {
+		slog.Warn(
+			"op dropped from read-only sender",
 			"room_id", r.ID,
 			"client_id", msg.Sender.ID,
 			"bytes", len(msg.Data),
@@ -251,7 +302,7 @@ func (r *Room) broadcastMembershipLocked(subjectID string, event byte, exclude *
 		return
 	}
 	frame := wire.EncodeMembershipFrame(id, event)
-	for cl := range r.clients {
+	for _, cl := range r.clients {
 		if cl == exclude {
 			continue
 		}
@@ -262,11 +313,55 @@ func (r *Room) broadcastMembershipLocked(subjectID string, event byte, exclude *
 	}
 }
 
+func (r *Room) sendRosterLocked(joiner *client.Client) {
+	for _, member := range r.clients {
+		frame, ok := encodePeerInfo(member)
+		if !ok {
+			continue
+		}
+		if !joiner.Send(frame) {
+			slog.Warn("roster: send failed (slow client); force-closing", "room_id", r.ID, "client_id", joiner.ID)
+			joiner.ForceClose()
+			return
+		}
+	}
+}
+
+func (r *Room) announcePeerLocked(joiner *client.Client) {
+	frame, ok := encodePeerInfo(joiner)
+	if !ok {
+		return
+	}
+	for _, member := range r.clients {
+		if member == joiner {
+			continue
+		}
+		if !member.Send(frame) {
+			slog.Warn("peer-info: send failed (slow client); force-closing", "room_id", r.ID, "client_id", member.ID)
+			member.ForceClose()
+		}
+	}
+}
+
+func encodePeerInfo(c *client.Client) (frame []byte, ok bool) {
+	id, err := strconv.ParseUint(c.ID, 10, 64)
+	if err != nil {
+		slog.Warn("peer-info: non-numeric client_id; skipping", "client_id", c.ID, "error", err)
+		return nil, false
+	}
+	frame, err = wire.EncodePeerInfoFrame(id, c.IsHost(), c.CanWrite(), c.Username)
+	if err != nil {
+		slog.Warn("peer-info: encode failed; skipping", "client_id", c.ID, "error", err)
+		return nil, false
+	}
+	return frame, true
+}
+
 func (r *Room) getPeers(exclude *client.Client) []*client.Client {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	targets := make([]*client.Client, 0, len(r.clients))
-	for c := range r.clients {
+	for _, c := range r.clients {
 		if exclude == nil || c != exclude {
 			targets = append(targets, c)
 		}
@@ -293,11 +388,7 @@ func (r *Room) drain() {
 		select {
 		case msg := <-r.ops:
 			drained++
-			if wire.IsSnapshotFrame(msg.Data) {
-				_ = r.deliverSnapshotResponse(msg.Sender, msg.Data)
-			} else {
-				r.broadcast(msg)
-			}
+			r.dispatch(msg)
 		default:
 			slog.Debug("room drain finished", "room_id", r.ID, "drained_messages", drained)
 			return

--- a/gateway/internal/room/room.go
+++ b/gateway/internal/room/room.go
@@ -30,10 +30,10 @@ type BroadcastMsg struct {
 type Room struct {
 	ID string
 
-	mu      sync.Mutex
-	clients map[string]*client.Client
-	closed  bool
-	host    *client.Client
+	mu              sync.Mutex
+	clients         map[string]*client.Client
+	closed          bool
+	host            *client.Client
 	defaultCanWrite bool
 
 	snapshotRequests []chan []byte

--- a/gateway/internal/room/room_test.go
+++ b/gateway/internal/room/room_test.go
@@ -37,8 +37,8 @@ func TestRoom_JoinLeaveTriggersOnEmpty(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	a := client.New("a", "room-1", nil)
-	b := client.New("b", "room-1", nil)
+	a := client.New("a", "room-1", "userA", nil)
+	b := client.New("b", "room-1", "userB", nil)
 	if err := r.Join(a); err != nil {
 		t.Fatalf("join a: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestRoom_SendToEmptyIsNoop(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	a := client.New("a", "room-2", nil)
+	a := client.New("a", "room-2", "userA", nil)
 	if err := r.Join(a); err != nil {
 		t.Fatalf("join: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestRoom_DoubleLeaveIsSilent(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	a := client.New("a", "room-3", nil)
+	a := client.New("a", "room-3", "userA", nil)
 	if err := r.Join(a); err != nil {
 		t.Fatalf("join: %v", err)
 	}
@@ -112,13 +112,13 @@ func TestRoom_JoinAfterCloseIsRejected(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	a := client.New("a", "room-4", nil)
+	a := client.New("a", "room-4", "userA", nil)
 	if err := r.Join(a); err != nil {
 		t.Fatalf("join: %v", err)
 	}
 	r.Leave(a, nil)
 
-	b := client.New("b", "room-4", nil)
+	b := client.New("b", "room-4", "userB", nil)
 	if err := r.Join(b); !errors.Is(err, ErrRoomClosed) {
 		t.Fatalf("Join on closed room: got %v, want ErrRoomClosed", err)
 	}
@@ -131,12 +131,12 @@ func TestRoom_SnapshotReplayToJoiner(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	host := client.New("host", "room-snap", nil)
+	host := client.New("host", "room-snap", "hostUser", nil)
 	if err := r.Join(host); err != nil {
 		t.Fatalf("join host: %v", err)
 	}
 
-	joiner := client.New("joiner", "room-snap", nil)
+	joiner := client.New("joiner", "room-snap", "joinerUser", nil)
 	if err := r.Join(joiner); err != nil {
 		t.Fatalf("join joiner: %v", err)
 	}
@@ -205,8 +205,8 @@ func TestRoom_DuplicateClientIDRejected(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	a := client.New("same", "room-dup", nil)
-	b := client.New("same", "room-dup", nil)
+	a := client.New("same", "room-dup", "dupUser", nil)
+	b := client.New("same", "room-dup", "dupUser", nil)
 	if err := r.Join(a); err != nil {
 		t.Fatalf("first join: %v", err)
 	}
@@ -218,16 +218,36 @@ func TestRoom_DuplicateClientIDRejected(t *testing.T) {
 	<-runDone
 }
 
+func containsFrame(frames [][]byte, want []byte) bool {
+	for _, f := range frames {
+		if bytes.Equal(f, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustEncodePeerInfo(t *testing.T, clientID uint64, isHost, canWrite bool, username string) []byte {
+	t.Helper()
+	frame, err := wire.EncodePeerInfoFrame(clientID, isHost, canWrite, username)
+	if err != nil {
+		t.Fatalf("EncodePeerInfoFrame: %v", err)
+	}
+	return frame
+}
+
 func TestRoom_JoinBroadcastsMembershipToExistingMembers(t *testing.T) {
 	r := New("room-membership-join", gatewaymetrics.New())
-	host := client.New("1", "room-membership-join", nil)
-	guest := client.New("2", "room-membership-join", nil)
+	host := client.New("1", "room-membership-join", "hostname", nil)
+	guest := client.New("2", "room-membership-join", "guestname", nil)
 
 	if err := r.Join(host); err != nil {
 		t.Fatalf("join host: %v", err)
 	}
-	if got := drainFrames(host); len(got) != 0 {
-		t.Fatalf("first joiner received %d frames, want 0", len(got))
+	wantHostInfo := mustEncodePeerInfo(t, 1, true, true, "hostname")
+	hostRoster := drainFrames(host)
+	if len(hostRoster) != 1 || !bytes.Equal(hostRoster[0], wantHostInfo) {
+		t.Fatalf("first joiner roster = %x, want [%x]", hostRoster, wantHostInfo)
 	}
 
 	if err := r.Join(guest); err != nil {
@@ -235,23 +255,31 @@ func TestRoom_JoinBroadcastsMembershipToExistingMembers(t *testing.T) {
 	}
 
 	hostFrames := drainFrames(host)
-	if len(hostFrames) != 1 {
-		t.Fatalf("host received %d frames, want 1 (joined guest)", len(hostFrames))
+	if len(hostFrames) != 2 {
+		t.Fatalf("host received %d frames, want 2 (membership + peer-info for guest)", len(hostFrames))
 	}
-	want := wire.EncodeMembershipFrame(2, wire.MembershipJoined)
-	if !bytes.Equal(hostFrames[0], want) {
-		t.Fatalf("host received %x, want membership-joined for client 2 %x", hostFrames[0], want)
+	wantJoined := wire.EncodeMembershipFrame(2, wire.MembershipJoined)
+	if !bytes.Equal(hostFrames[0], wantJoined) {
+		t.Fatalf("host received %x, want membership-joined for client 2 %x", hostFrames[0], wantJoined)
+	}
+	wantGuestInfo := mustEncodePeerInfo(t, 2, false, false, "guestname")
+	if !bytes.Equal(hostFrames[1], wantGuestInfo) {
+		t.Fatalf("host received %x, want peer-info for guest %x", hostFrames[1], wantGuestInfo)
 	}
 
-	if got := drainFrames(guest); len(got) != 0 {
-		t.Fatalf("joiner received its own membership (%d frames), want 0", len(got))
+	guestRoster := drainFrames(guest)
+	if len(guestRoster) != 2 {
+		t.Fatalf("joiner received %d frames, want 2 (roster: host + self)", len(guestRoster))
+	}
+	if !containsFrame(guestRoster, wantHostInfo) || !containsFrame(guestRoster, wantGuestInfo) {
+		t.Fatalf("joiner roster %x missing host or self peer-info", guestRoster)
 	}
 }
 
 func TestRoom_LeaveBroadcastsMembershipToRemaining(t *testing.T) {
 	r := New("room-membership-leave", gatewaymetrics.New())
-	host := client.New("1", "room-membership-leave", nil)
-	guest := client.New("2", "room-membership-leave", nil)
+	host := client.New("1", "room-membership-leave", "hostname", nil)
+	guest := client.New("2", "room-membership-leave", "guestname", nil)
 	_ = r.Join(host)
 	_ = r.Join(guest)
 	_ = drainFrames(host) // discard joined(guest)
@@ -273,8 +301,8 @@ func TestRoom_NonNumericClientIDSkipsMembership(t *testing.T) {
 	// the fixed u64 membership layout, so the join/leave proceeds without membership
 	// rather than failing.
 	r := New("room-membership-nonnumeric", gatewaymetrics.New())
-	host := client.New("1", "room-membership-nonnumeric", nil)
-	weird := client.New("not-a-number", "room-membership-nonnumeric", nil)
+	host := client.New("1", "room-membership-nonnumeric", "hostname", nil)
+	weird := client.New("not-a-number", "room-membership-nonnumeric", "weird", nil)
 	_ = r.Join(host)
 	_ = drainFrames(host)
 
@@ -291,8 +319,8 @@ func TestRoom_GcCommitBroadcastsToPeers(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	host := client.New("1", "room-gc", nil)
-	guest := client.New("2", "room-gc", nil)
+	host := client.New("1", "room-gc", "hostname", nil)
+	guest := client.New("2", "room-gc", "guestname", nil)
 	_ = r.Join(host)
 	_ = r.Join(guest)
 	_ = drainFrames(host)
@@ -315,13 +343,178 @@ func TestRoom_GcCommitBroadcastsToPeers(t *testing.T) {
 	<-runDone
 }
 
+func TestRoom_FirstJoinerBecomesHostGuestsReadOnlyByDefault(t *testing.T) {
+	r := New("room-roles", gatewaymetrics.New())
+	host := client.New("1", "room-roles", "hostname", nil)
+	guest := client.New("2", "room-roles", "guestname", nil)
+	if err := r.Join(host); err != nil {
+		t.Fatalf("join host: %v", err)
+	}
+	if err := r.Join(guest); err != nil {
+		t.Fatalf("join guest: %v", err)
+	}
+
+	if host.Role() != client.RoleHost {
+		t.Fatal("first joiner was not assigned RoleHost")
+	}
+	if guest.Role() != client.RoleGuest {
+		t.Fatal("second joiner was not assigned RoleGuest")
+	}
+	if !host.CanWrite() {
+		t.Fatal("host must always have write access")
+	}
+	if guest.CanWrite() {
+		t.Fatal("guest should be read-only when the host did not opt into default_can_write")
+	}
+}
+
+func TestRoom_HostDefaultCanWriteGrantsGuests(t *testing.T) {
+	r := New("room-default-write", gatewaymetrics.New())
+	host := client.New("1", "room-default-write", "hostname", nil)
+	host.HostDefaultCanWrite = true
+	guest := client.New("2", "room-default-write", "guestname", nil)
+	_ = r.Join(host)
+	_ = r.Join(guest)
+
+	if !guest.CanWrite() {
+		t.Fatal("guest should inherit write access from the host's default_can_write")
+	}
+}
+
+func TestRoom_OpFromReadOnlyGuestIsDropped(t *testing.T) {
+	r := New("room-readonly-op", gatewaymetrics.New())
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	host := client.New("1", "room-readonly-op", "hostname", nil)
+	guest := client.New("2", "room-readonly-op", "guestname", nil)
+	_ = r.Join(host)
+	_ = r.Join(guest)
+	_ = drainFrames(host)
+	_ = drainFrames(guest)
+
+	op := []byte{wire.PrefixOp, 0xAA}
+	r.Ops() <- BroadcastMsg{Sender: guest, Data: op}
+
+	select {
+	case f := <-host.SendChan():
+		t.Fatalf("host received op %x from read-only guest, want drop", f)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	r.Leave(host, nil)
+	r.Leave(guest, nil)
+	<-runDone
+}
+
+func TestRoom_PermissionChangeGrantsWriteAndBroadcasts(t *testing.T) {
+	r := New("room-perm-grant", gatewaymetrics.New())
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	host := client.New("1", "room-perm-grant", "hostname", nil)
+	guest := client.New("2", "room-perm-grant", "guestname", nil)
+	_ = r.Join(host)
+	_ = r.Join(guest)
+	_ = drainFrames(host)
+	_ = drainFrames(guest)
+
+	grant := wire.EncodePermissionFrame(2, true)
+	r.Ops() <- BroadcastMsg{Sender: host, Data: grant}
+
+	for _, c := range []*client.Client{host, guest} {
+		select {
+		case f := <-c.SendChan():
+			if !bytes.Equal(f, grant) {
+				t.Fatalf("client %s received %x, want permission frame %x", c.ID, f, grant)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("client %s did not receive the permission broadcast", c.ID)
+		}
+	}
+	if !guest.CanWrite() {
+		t.Fatal("guest write permission was not applied")
+	}
+
+	op := []byte{wire.PrefixOp, 0xBB}
+	r.Ops() <- BroadcastMsg{Sender: guest, Data: op}
+	select {
+	case f := <-host.SendChan():
+		if !bytes.Equal(f, op) {
+			t.Fatalf("host received %x, want op %x", f, op)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("host did not receive op from granted guest")
+	}
+
+	r.Leave(host, nil)
+	r.Leave(guest, nil)
+	<-runDone
+}
+
+func TestRoom_PermissionChangeFromGuestIsDropped(t *testing.T) {
+	r := New("room-perm-guest", gatewaymetrics.New())
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	host := client.New("1", "room-perm-guest", "hostname", nil)
+	guest := client.New("2", "room-perm-guest", "guestname", nil)
+	_ = r.Join(host)
+	_ = r.Join(guest)
+	_ = drainFrames(host)
+	_ = drainFrames(guest)
+
+	r.Ops() <- BroadcastMsg{Sender: guest, Data: wire.EncodePermissionFrame(2, true)}
+
+	select {
+	case f := <-host.SendChan():
+		t.Fatalf("host received %x after guest-authored permission change, want drop", f)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if guest.CanWrite() {
+		t.Fatal("guest granted itself write access")
+	}
+
+	r.Leave(host, nil)
+	r.Leave(guest, nil)
+	<-runDone
+}
+
+func TestRoom_PermissionChangeForHostIsDropped(t *testing.T) {
+	r := New("room-perm-host", gatewaymetrics.New())
+	runDone := make(chan struct{})
+	go func() { r.Run(); close(runDone) }()
+
+	host := client.New("1", "room-perm-host", "hostname", nil)
+	guest := client.New("2", "room-perm-host", "guestname", nil)
+	_ = r.Join(host)
+	_ = r.Join(guest)
+	_ = drainFrames(host)
+	_ = drainFrames(guest)
+
+	r.Ops() <- BroadcastMsg{Sender: host, Data: wire.EncodePermissionFrame(1, false)}
+
+	select {
+	case f := <-guest.SendChan():
+		t.Fatalf("guest received %x after host-targeted permission change, want drop", f)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if !host.CanWrite() {
+		t.Fatal("host lost write access; host permission must be immutable")
+	}
+
+	r.Leave(host, nil)
+	r.Leave(guest, nil)
+	<-runDone
+}
+
 func TestRoom_GcCommitFromGuestIsDropped(t *testing.T) {
 	r := New("room-gc-guest", gatewaymetrics.New())
 	runDone := make(chan struct{})
 	go func() { r.Run(); close(runDone) }()
 
-	host := client.New("1", "room-gc-guest", nil)
-	guest := client.New("2", "room-gc-guest", nil)
+	host := client.New("1", "room-gc-guest", "hostname", nil)
+	guest := client.New("2", "room-gc-guest", "guestname", nil)
 	_ = r.Join(host)
 	_ = r.Join(guest)
 	_ = drainFrames(host)

--- a/gateway/internal/wire/protocol_drift_test.go
+++ b/gateway/internal/wire/protocol_drift_test.go
@@ -17,8 +17,12 @@ func TestPrefixConstantsMatchRustSource(t *testing.T) {
 		rustPrefixGcCommit   byte = 0x04
 		rustPrefixMembership byte = 0x05
 		rustPrefixSvReport   byte = 0x06
+		rustPrefixPermission byte = 0x07
+		rustPrefixPeerInfo   byte = 0x08
 		rustMembershipJoined byte = 0x01
 		rustMembershipLeft   byte = 0x02
+		rustPeerFlagHost     byte = 0x01
+		rustPeerFlagCanWrite byte = 0x02
 	)
 
 	if PrefixOp != rustOpPrefix {
@@ -51,6 +55,18 @@ func TestPrefixConstantsMatchRustSource(t *testing.T) {
 	if MembershipLeft != rustMembershipLeft {
 		t.Fatalf("MembershipLeft = %#x, rust PEER_LEFT = %#x — protocol drift", MembershipLeft, rustMembershipLeft)
 	}
+	if PrefixPermission != rustPrefixPermission {
+		t.Fatalf("PrefixPermission = %#x, rust PREFIX_PERMISSION = %#x — protocol drift", PrefixPermission, rustPrefixPermission)
+	}
+	if PrefixPeerInfo != rustPrefixPeerInfo {
+		t.Fatalf("PrefixPeerInfo = %#x, rust PREFIX_PEER_INFO = %#x — protocol drift", PrefixPeerInfo, rustPrefixPeerInfo)
+	}
+	if PeerFlagHost != rustPeerFlagHost {
+		t.Fatalf("PeerFlagHost = %#x, rust PEER_FLAG_HOST = %#x — protocol drift", PeerFlagHost, rustPeerFlagHost)
+	}
+	if PeerFlagCanWrite != rustPeerFlagCanWrite {
+		t.Fatalf("PeerFlagCanWrite = %#x, rust PEER_FLAG_CAN_WRITE = %#x — protocol drift", PeerFlagCanWrite, rustPeerFlagCanWrite)
+	}
 }
 
 func TestMembershipLayoutMatchesRustSource(t *testing.T) {
@@ -60,5 +76,28 @@ func TestMembershipLayoutMatchesRustSource(t *testing.T) {
 	want := []byte{PrefixMembership, MembershipJoined, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("EncodeMembershipFrame layout = %x, want %x — protocol drift", got, want)
+	}
+}
+
+func TestPermissionLayoutMatchesRustSource(t *testing.T) {
+	got := EncodePermissionFrame(0x0102030405060708, true)
+	want := []byte{PrefixPermission, 0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("EncodePermissionFrame layout = %x, want %x — protocol drift", got, want)
+	}
+}
+
+func TestPeerInfoLayoutMatchesRustSource(t *testing.T) {
+	got, err := EncodePeerInfoFrame(0x0102030405060708, true, true, "ab")
+	if err != nil {
+		t.Fatalf("EncodePeerInfoFrame: %v", err)
+	}
+	want := []byte{
+		PrefixPeerInfo, PeerFlagHost | PeerFlagCanWrite,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x02, 'a', 'b',
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("EncodePeerInfoFrame layout = %x, want %x — protocol drift", got, want)
 	}
 }

--- a/gateway/internal/wire/wire.go
+++ b/gateway/internal/wire/wire.go
@@ -13,6 +13,8 @@ const (
 	PrefixGcCommit   byte = 0x04
 	PrefixMembership byte = 0x05
 	PrefixSvReport   byte = 0x06
+	PrefixPermission byte = 0x07
+	PrefixPeerInfo   byte = 0x08
 )
 
 const (
@@ -24,6 +26,13 @@ const (
 	MembershipJoined byte = 0x01
 	MembershipLeft   byte = 0x02
 )
+
+const (
+	PeerFlagHost     byte = 0x01
+	PeerFlagCanWrite byte = 0x02
+)
+
+const MaxUsernameBytes = 255
 
 func EncodeControlFrame(controlType byte) []byte {
 	return []byte{PrefixControl, controlType}
@@ -38,8 +47,11 @@ func EncodeMembershipFrame(clientID uint64, event byte) []byte {
 }
 
 var (
-	ErrEmptyFrame    = errors.New("wire: empty frame")
-	ErrUnknownPrefix = errors.New("wire: unknown prefix")
+	ErrEmptyFrame      = errors.New("wire: empty frame")
+	ErrUnknownPrefix   = errors.New("wire: unknown prefix")
+	ErrMalformedFrame  = errors.New("wire: malformed frame")
+	ErrUsernameTooLong = errors.New("wire: username exceeds max bytes")
+	ErrNotAPermission  = errors.New("wire: not a permission frame")
 )
 
 func ValidateFrame(frame []byte) error {
@@ -47,12 +59,61 @@ func ValidateFrame(frame []byte) error {
 		return ErrEmptyFrame
 	}
 	switch frame[0] {
-	// PrefixMembership is gateway-authored only; an inbound one is rejected.
-	case PrefixOp, PrefixSnapshot, PrefixGcCommit, PrefixSvReport:
+	case PrefixOp, PrefixSnapshot, PrefixGcCommit, PrefixSvReport, PrefixPermission:
 		return nil
 	default:
 		return fmt.Errorf("%w: 0x%02X", ErrUnknownPrefix, frame[0])
 	}
+}
+
+func IsOpFrame(frame []byte) bool {
+	return len(frame) > 0 && frame[0] == PrefixOp
+}
+
+func IsPermissionFrame(frame []byte) bool {
+	return len(frame) > 0 && frame[0] == PrefixPermission
+}
+
+func EncodePermissionFrame(clientID uint64, canWrite bool) []byte {
+	out := make([]byte, 10)
+	out[0] = PrefixPermission
+	if canWrite {
+		out[1] = 1
+	}
+	binary.BigEndian.PutUint64(out[2:], clientID)
+	return out
+}
+
+func DecodePermissionFrame(frame []byte) (clientID uint64, canWrite bool, err error) {
+	if len(frame) == 0 {
+		return 0, false, ErrEmptyFrame
+	}
+	if frame[0] != PrefixPermission {
+		return 0, false, ErrNotAPermission
+	}
+	if len(frame) != 10 || frame[1] > 1 {
+		return 0, false, fmt.Errorf("%w: permission frame", ErrMalformedFrame)
+	}
+	return binary.BigEndian.Uint64(frame[2:]), frame[1] == 1, nil
+}
+
+func EncodePeerInfoFrame(clientID uint64, isHost, canWrite bool, username string) ([]byte, error) {
+	if len(username) > MaxUsernameBytes {
+		return nil, ErrUsernameTooLong
+	}
+	var flags byte
+	if isHost {
+		flags |= PeerFlagHost
+	}
+	if canWrite {
+		flags |= PeerFlagCanWrite
+	}
+	out := make([]byte, 0, 11+len(username))
+	out = append(out, PrefixPeerInfo, flags)
+	out = binary.BigEndian.AppendUint64(out, clientID)
+	out = append(out, byte(len(username)))
+	out = append(out, username...)
+	return out, nil
 }
 
 func DecodeOpFrame(frame []byte) ([]byte, error) {

--- a/gateway/internal/wire/wire_test.go
+++ b/gateway/internal/wire/wire_test.go
@@ -92,6 +92,83 @@ func TestValidateFrame_RejectsInboundMembership(t *testing.T) {
 	}
 }
 
+func TestValidateFrame_AcceptsPermission(t *testing.T) {
+	if err := ValidateFrame(EncodePermissionFrame(1, true)); err != nil {
+		t.Fatalf("ValidateFrame(permission) = %v, want nil", err)
+	}
+}
+
+func TestValidateFrame_RejectsInboundPeerInfo(t *testing.T) {
+	frame, err := EncodePeerInfoFrame(1, false, true, "alice")
+	if err != nil {
+		t.Fatalf("EncodePeerInfoFrame: %v", err)
+	}
+	if err := ValidateFrame(frame); !errors.Is(err, ErrUnknownPrefix) {
+		t.Fatalf("ValidateFrame(peer-info) = %v, want ErrUnknownPrefix", err)
+	}
+}
+
+func TestPermissionFrame_RoundTrip(t *testing.T) {
+	for _, canWrite := range []bool{true, false} {
+		frame := EncodePermissionFrame(0x0102030405060708, canWrite)
+		id, got, err := DecodePermissionFrame(frame)
+		if err != nil {
+			t.Fatalf("DecodePermissionFrame: %v", err)
+		}
+		if id != 0x0102030405060708 || got != canWrite {
+			t.Fatalf("round trip = (%#x, %v), want (0x0102030405060708, %v)", id, got, canWrite)
+		}
+	}
+}
+
+func TestDecodePermissionFrame_Rejects(t *testing.T) {
+	if _, _, err := DecodePermissionFrame(nil); !errors.Is(err, ErrEmptyFrame) {
+		t.Fatalf("nil frame err = %v, want ErrEmptyFrame", err)
+	}
+	if _, _, err := DecodePermissionFrame([]byte{PrefixOp, 1}); !errors.Is(err, ErrNotAPermission) {
+		t.Fatalf("op frame err = %v, want ErrNotAPermission", err)
+	}
+	if _, _, err := DecodePermissionFrame([]byte{PrefixPermission, 1, 0}); !errors.Is(err, ErrMalformedFrame) {
+		t.Fatalf("short frame err = %v, want ErrMalformedFrame", err)
+	}
+	bad := EncodePermissionFrame(1, false)
+	bad[1] = 0x02
+	if _, _, err := DecodePermissionFrame(bad); !errors.Is(err, ErrMalformedFrame) {
+		t.Fatalf("bad flag err = %v, want ErrMalformedFrame", err)
+	}
+}
+
+func TestEncodePeerInfoFrame_Layout(t *testing.T) {
+	frame, err := EncodePeerInfoFrame(0x0102030405060708, true, true, "ab")
+	if err != nil {
+		t.Fatalf("EncodePeerInfoFrame: %v", err)
+	}
+	want := []byte{
+		PrefixPeerInfo, PeerFlagHost | PeerFlagCanWrite,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x02, 'a', 'b',
+	}
+	if !bytes.Equal(frame, want) {
+		t.Fatalf("frame = %x, want %x", frame, want)
+	}
+}
+
+func TestEncodePeerInfoFrame_RejectsOversizedUsername(t *testing.T) {
+	long := bytes.Repeat([]byte{'x'}, MaxUsernameBytes+1)
+	if _, err := EncodePeerInfoFrame(1, false, false, string(long)); !errors.Is(err, ErrUsernameTooLong) {
+		t.Fatalf("err = %v, want ErrUsernameTooLong", err)
+	}
+}
+
+func TestIsOpAndPermissionFrameHelpers(t *testing.T) {
+	if !IsOpFrame([]byte{PrefixOp, 0x01}) || IsOpFrame([]byte{PrefixSnapshot}) || IsOpFrame(nil) {
+		t.Fatal("IsOpFrame misclassified a frame")
+	}
+	if !IsPermissionFrame(EncodePermissionFrame(1, true)) || IsPermissionFrame([]byte{PrefixOp}) || IsPermissionFrame(nil) {
+		t.Fatal("IsPermissionFrame misclassified a frame")
+	}
+}
+
 func TestValidateFrame_RejectsUnknown(t *testing.T) {
 	if err := ValidateFrame([]byte{0xFF}); !errors.Is(err, ErrUnknownPrefix) {
 		t.Fatalf("ValidateFrame(0xFF) = %v, want ErrUnknownPrefix", err)

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -792,9 +792,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -873,9 +873,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2577,9 +2577,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2950,9 +2950,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/tauri-app/src-tauri/src/app_config/commands.rs
+++ b/tauri-app/src-tauri/src/app_config/commands.rs
@@ -1,0 +1,36 @@
+use log::{debug, info};
+use tauri::AppHandle;
+
+use crate::app_config::identity::{self, PersistedIdentity};
+
+#[derive(serde::Serialize)]
+pub struct IdentityDto {
+    pub username: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_identity(app: AppHandle) -> Result<IdentityDto, String> {
+    let id = identity::load_raw(&app)?;
+    debug!(
+        "get_identity completed: has_username={}",
+        id.username.is_some()
+    );
+    Ok(IdentityDto {
+        username: id.username,
+    })
+}
+
+#[tauri::command]
+pub fn set_username(app: AppHandle, username: String) -> Result<(), String> {
+    info!(
+        "set_username requested: input_len={}",
+        username.chars().count()
+    );
+    let clean = identity::sanitize_username(&username).ok_or("username must not be empty")?;
+    identity::persist(
+        &app,
+        &PersistedIdentity {
+            username: Some(clean),
+        },
+    )
+}

--- a/tauri-app/src-tauri/src/app_config/identity.rs
+++ b/tauri-app/src-tauri/src/app_config/identity.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use log::{debug, info};
+use log::info;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
@@ -9,8 +9,8 @@ const IDENTITY_FILE: &str = "identity.toml";
 const MAX_USERNAME_LEN: usize = 32;
 
 #[derive(Debug, Serialize, Deserialize)]
-struct PersistedIdentity {
-    username: Option<String>,
+pub(super) struct PersistedIdentity {
+    pub(super) username: Option<String>,
 }
 
 fn identity_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -21,7 +21,7 @@ fn identity_path(app: &AppHandle) -> Result<PathBuf, String> {
         .join(IDENTITY_FILE))
 }
 
-fn load_raw(app: &AppHandle) -> Result<PersistedIdentity, String> {
+pub(super) fn load_raw(app: &AppHandle) -> Result<PersistedIdentity, String> {
     let path = identity_path(app)?;
     Ok(fs::read_to_string(&path)
         .ok()
@@ -29,7 +29,7 @@ fn load_raw(app: &AppHandle) -> Result<PersistedIdentity, String> {
         .unwrap_or(PersistedIdentity { username: None }))
 }
 
-fn persist(app: &AppHandle, identity: &PersistedIdentity) -> Result<(), String> {
+pub(super) fn persist(app: &AppHandle, identity: &PersistedIdentity) -> Result<(), String> {
     let path = identity_path(app)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
@@ -51,34 +51,9 @@ pub fn sanitize_username(raw: &str) -> Option<String> {
     Some(trimmed.chars().take(MAX_USERNAME_LEN).collect())
 }
 
-#[derive(serde::Serialize)]
-pub struct IdentityDto {
-    pub username: Option<String>,
-}
-
-#[tauri::command]
-pub fn get_identity(app: AppHandle) -> Result<IdentityDto, String> {
-    let id = load_raw(&app)?;
-    debug!(
-        "get_identity completed: has_username={}",
-        id.username.is_some()
-    );
-    Ok(IdentityDto {
-        username: id.username,
-    })
-}
-
-#[tauri::command]
-pub fn set_username(app: AppHandle, username: String) -> Result<(), String> {
-    info!(
-        "set_username requested: input_len={}",
-        username.chars().count()
-    );
-    let clean = sanitize_username(&username).ok_or("username must not be empty")?;
-    persist(
-        &app,
-        &PersistedIdentity {
-            username: Some(clean),
-        },
-    )
+pub fn read_username(app: &AppHandle) -> String {
+    load_raw(app)
+        .ok()
+        .and_then(|id| id.username)
+        .unwrap_or_default()
 }

--- a/tauri-app/src-tauri/src/app_config/mod.rs
+++ b/tauri-app/src-tauri/src/app_config/mod.rs
@@ -1,3 +1,4 @@
+pub mod commands;
 pub mod config;
 
 pub mod identity;

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -9,7 +9,6 @@ mod state;
 mod ws_management;
 
 use crate::app_config::config::AppConfig;
-use crate::app_config::identity;
 #[cfg(debug_assertions)]
 use crate::debug::document_logger::spawn_linked_list_logger;
 use crate::gateway::gateway_api::destroy_room;
@@ -112,9 +111,10 @@ pub fn run() {
             session::guest_commands::parse_join_url,
             session::joint_commands::get_session_info,
             session::joint_commands::leave_session,
+            session::permission_commands::set_peer_permission,
             processes::commands::get_process_status,
-            identity::get_identity,
-            identity::set_username,
+            app_config::commands::get_identity,
+            app_config::commands::set_username,
             persistence::commands::open_file,
             persistence::commands::save_file,
             persistence::commands::save_file_as,

--- a/tauri-app/src-tauri/src/session/guest_commands.rs
+++ b/tauri-app/src-tauri/src/session/guest_commands.rs
@@ -1,10 +1,13 @@
+use crate::app_config::identity;
 use crate::session::session_types::{JoinInfo, ProcessesStoppedPayload, PROCESSES_STOPPED};
 use crate::state::appstate::AppState;
 use crate::state::document::{request, DocOp};
+use crate::state::roster;
 use crate::state::ws_state::WsState;
 use crate::ws_management::disconnect_handler::spawn_disconnect_handler;
 use log::{debug, info, warn};
 use tauri::{AppHandle, Emitter, State};
+use url::form_urlencoded::byte_serialize;
 use url::Url;
 
 #[tauri::command]
@@ -40,9 +43,10 @@ pub async fn join_session(
         })?
         .value;
 
+    let username: String = byte_serialize(identity::read_username(&app).as_bytes()).collect();
     let ws_url = format!(
-        "{}/ws?room={}&client_id={}",
-        join_info.server_url, join_info.room_id, guest_client_id
+        "{}/ws?room={}&client_id={}&username={}",
+        join_info.server_url, join_info.room_id, guest_client_id, username
     );
     debug!(
         "join_session attempting websocket connect: room_id={} client_id={}",
@@ -71,6 +75,7 @@ pub async fn join_session(
                 "join_session role transitioned to Guest: room_id={}",
                 join_info.room_id
             );
+            roster::resync_own_permission(&app, guest_client_id);
             state.sync_maintenance.start_guest_sv_reporter(app.clone());
             spawn_disconnect_handler(app, disconnect_rx);
             Ok(())

--- a/tauri-app/src-tauri/src/session/host_commands.rs
+++ b/tauri-app/src-tauri/src/session/host_commands.rs
@@ -1,3 +1,4 @@
+use crate::app_config::identity;
 use crate::gateway::gateway_api::{create_room, destroy_room};
 use crate::processes::process_coordinator;
 use crate::session::session_types::{HostSessionSetup, SessionReadyPayload, SESSION_READY};
@@ -9,10 +10,11 @@ use crate::ws_management::ws_types::DisconnectReason;
 use log::{debug, error, info, warn};
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::oneshot;
+use url::form_urlencoded::byte_serialize;
 
 #[tauri::command]
-pub async fn host_session(app: AppHandle) -> Result<(), String> {
-    debug!("start_host_session requested");
+pub async fn host_session(app: AppHandle, guests_can_write: bool) -> Result<(), String> {
+    debug!("start_host_session requested: guests_can_write={guests_can_write}");
 
     let guard = app
         .state::<AppState>()
@@ -25,7 +27,7 @@ pub async fn host_session(app: AppHandle) -> Result<(), String> {
 
     let setup = prepare_host_session(&app).await?;
 
-    let disconnect_rx = connect(&app, setup.port, setup.room_id.clone()).await?;
+    let disconnect_rx = connect(&app, setup.port, setup.room_id.clone(), guests_can_write).await?;
 
     app.state::<AppState>().complete_host(
         guard,
@@ -140,6 +142,7 @@ async fn connect(
     app: &AppHandle,
     port: u16,
     room_id: String,
+    guests_can_write: bool,
 ) -> Result<oneshot::Receiver<DisconnectReason>, String> {
     debug!(
         "host local connect requested: room_id={} port={}",
@@ -150,8 +153,11 @@ async fn connect(
         e
     })?;
 
-    let local_ws_url =
-        format!("ws://127.0.0.1:{port}/ws?room={room_id}&client_id={host_client_id}");
+    let username: String = byte_serialize(identity::read_username(app).as_bytes()).collect();
+    let local_ws_url = format!(
+        "ws://127.0.0.1:{port}/ws?room={room_id}&client_id={host_client_id}\
+         &username={username}&default_can_write={guests_can_write}"
+    );
     let ws = app.state::<WsState>();
     let disconnect_rx = ws
         .connect(&local_ws_url, room_id.clone(), app.clone())

--- a/tauri-app/src-tauri/src/session/joint_commands.rs
+++ b/tauri-app/src-tauri/src/session/joint_commands.rs
@@ -1,8 +1,8 @@
-use crate::session::session_types::SessionInfo;
+use crate::session::session_types::{CanWritePayload, SessionInfo, CAN_WRITE_CHANGED};
 use crate::state::appstate::{AppRole, AppState};
 use crate::state::ws_state::WsState;
 use log::{debug, info, warn};
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 #[tauri::command]
 pub fn get_session_info(state: State<'_, AppState>) -> SessionInfo {
@@ -25,6 +25,7 @@ pub fn get_session_info(state: State<'_, AppState>) -> SessionInfo {
         AppRole::Guest {
             room_id,
             server_url,
+            ..
         } => (None, Some(server_url), None, None, Some(room_id)),
         _ => (None, None, None, None, None),
     };
@@ -41,7 +42,11 @@ pub fn get_session_info(state: State<'_, AppState>) -> SessionInfo {
 }
 
 #[tauri::command]
-pub fn leave_session(state: State<'_, AppState>, ws: State<'_, WsState>) -> Result<(), String> {
+pub fn leave_session(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    ws: State<'_, WsState>,
+) -> Result<(), String> {
     info!("leave session requested");
     state.leave_session(&ws);
     match state.transition_role(AppRole::Undecided) {
@@ -51,6 +56,7 @@ pub fn leave_session(state: State<'_, AppState>, ws: State<'_, WsState>) -> Resu
         ),
         Err(e) => warn!("leave_session: {e}"),
     }
+    let _ = app.emit(CAN_WRITE_CHANGED, CanWritePayload { can_write: true });
     info!("leave session completed");
     Ok(())
 }

--- a/tauri-app/src-tauri/src/session/mod.rs
+++ b/tauri-app/src-tauri/src/session/mod.rs
@@ -3,4 +3,5 @@ mod command_tests;
 pub(crate) mod guest_commands;
 pub mod host_commands;
 pub(crate) mod joint_commands;
+pub(crate) mod permission_commands;
 pub mod session_types;

--- a/tauri-app/src-tauri/src/session/permission_commands.rs
+++ b/tauri-app/src-tauri/src/session/permission_commands.rs
@@ -1,0 +1,36 @@
+use crate::state::appstate::AppState;
+use crate::state::ws_state::WsState;
+use crdt_core::types::ClientId;
+use crdt_core::wire::{encode_permission, PermissionFrame};
+use log::{info, warn};
+use tauri::State;
+
+/// Host-only: asks the gateway to grant/revoke a guest's write access. The
+/// gateway validates the sender and echoes the authoritative permission frame
+/// to every client (this one included), which is what updates local state.
+#[tauri::command]
+pub async fn set_peer_permission(
+    target_client_id: String,
+    can_write: bool,
+    state: State<'_, AppState>,
+    ws: State<'_, WsState>,
+) -> Result<(), String> {
+    info!("set_peer_permission requested: target={target_client_id}, can_write={can_write}");
+
+    if !state.is_host() {
+        warn!("set_peer_permission rejected: caller is not host");
+        return Err("Only the host can change permissions".into());
+    }
+
+    let target = target_client_id
+        .parse::<u64>()
+        .map_err(|_| format!("Invalid client id: {target_client_id}"))?;
+
+    let frame = encode_permission(&PermissionFrame {
+        client_id: ClientId::new(target),
+        can_write,
+    });
+    ws.send_raw(frame).await?;
+    info!("set_peer_permission: permission frame sent to gateway");
+    Ok(())
+}

--- a/tauri-app/src-tauri/src/session/session_types.rs
+++ b/tauri-app/src-tauri/src/session/session_types.rs
@@ -3,6 +3,13 @@ pub const SESSION_ERROR: &str = "session://session-error";
 pub const SESSION_ENDED: &str = "session://session-ended";
 pub const SESSION_DISCONNECTED: &str = "session://disconnected";
 pub const PROCESSES_STOPPED: &str = "session://processes-stopped";
+pub const ROOM_STATE_CHANGED: &str = "session://room-state";
+pub const CAN_WRITE_CHANGED: &str = "session://can-write";
+
+#[derive(Clone, serde::Serialize)]
+pub struct CanWritePayload {
+    pub can_write: bool,
+}
 
 #[derive(Clone, serde::Serialize)]
 pub struct ProcessesStoppedPayload {}

--- a/tauri-app/src-tauri/src/state/app_role.rs
+++ b/tauri-app/src-tauri/src/state/app_role.rs
@@ -2,6 +2,12 @@ use crate::state::appstate::AppState;
 use log::{info, warn};
 use tauri::{AppHandle, Manager};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WriteAccess {
+    ReadOnly,
+    Editable,
+}
+
 #[derive(Clone)]
 pub enum AppRole {
     Undecided,
@@ -16,6 +22,7 @@ pub enum AppRole {
     Guest {
         room_id: String,
         server_url: String,
+        write_access: WriteAccess,
     },
 }
 
@@ -126,6 +133,7 @@ impl AppState {
         match self.transition_role(AppRole::Guest {
             room_id,
             server_url,
+            write_access: WriteAccess::ReadOnly,
         }) {
             Ok(_) => {
                 guard.completed = true;
@@ -141,6 +149,26 @@ impl AppState {
 
     pub fn is_host(&self) -> bool {
         matches!(*self.role.lock().unwrap(), AppRole::Host { .. })
+    }
+
+    pub fn can_write(&self) -> bool {
+        match &*self.role.lock().unwrap() {
+            AppRole::Guest { write_access, .. } => *write_access == WriteAccess::Editable,
+            _ => true,
+        }
+    }
+
+    pub fn set_write_access(&self, access: WriteAccess) -> bool {
+        let mut role = self.role.lock().unwrap();
+        if let AppRole::Guest { write_access, .. } = &mut *role {
+            if *write_access != access {
+                info!("guest write access changed: {access:?}");
+            }
+            *write_access = access;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn store_public_url(&self, url: String) {

--- a/tauri-app/src-tauri/src/state/app_role.rs
+++ b/tauri-app/src-tauri/src/state/app_role.rs
@@ -8,6 +8,16 @@ pub enum WriteAccess {
     Editable,
 }
 
+impl WriteAccess {
+    pub fn from_can_write(can_write: bool) -> Self {
+        if can_write {
+            WriteAccess::Editable
+        } else {
+            WriteAccess::ReadOnly
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum AppRole {
     Undecided,

--- a/tauri-app/src-tauri/src/state/appstate.rs
+++ b/tauri-app/src-tauri/src/state/appstate.rs
@@ -1,6 +1,7 @@
 use crate::garbage_collection::SyncMaintenance;
 use crate::processes::types::{CombinedWorkflowResult, Sidecar, SidecarStatus};
 use crate::state::document::DocSender;
+use crate::state::roster::RosterState;
 use crate::state::ws_state::WsState;
 use log::{info, warn};
 #[cfg(debug_assertions)]
@@ -22,6 +23,7 @@ pub struct AppState {
     pub processes: Mutex<HostProcesses>,
     pub current_file: Mutex<Option<CurrentFile>>,
     pub sync_maintenance: SyncMaintenance,
+    pub roster: RosterState,
     #[cfg(debug_assertions)]
     pub crdt_logging_enabled: AtomicBool,
 }
@@ -74,6 +76,7 @@ impl AppState {
             }),
             current_file: Mutex::new(None),
             sync_maintenance: SyncMaintenance::new(),
+            roster: RosterState::default(),
             #[cfg(debug_assertions)]
             crdt_logging_enabled: AtomicBool::new(false),
         }
@@ -81,6 +84,7 @@ impl AppState {
 
     pub fn leave_session(&self, ws: &WsState) {
         self.sync_maintenance.stop_all();
+        self.roster.clear();
         ws.disconnect_nowait();
     }
 

--- a/tauri-app/src-tauri/src/state/document/commands.rs
+++ b/tauri-app/src-tauri/src/state/document/commands.rs
@@ -20,6 +20,14 @@ fn normalize_to_lf(content: String) -> String {
     }
 }
 
+fn ensure_can_write(state: &AppState) -> Result<(), String> {
+    if state.can_write() {
+        Ok(())
+    } else {
+        Err("Write permission denied: the host has made you read-only".into())
+    }
+}
+
 #[tauri::command]
 pub async fn insert(
     state: State<'_, AppState>,
@@ -28,6 +36,7 @@ pub async fn insert(
     content: String,
     base_seq: u64,
 ) -> Result<(), String> {
+    ensure_can_write(&state)?;
     let content = normalize_to_lf(content);
     debug!(
         "crdt insert request: position={}, content_len={}, base_seq={}",
@@ -65,6 +74,7 @@ pub async fn delete(
     length: u64,
     base_seq: u64,
 ) -> Result<(), String> {
+    ensure_can_write(&state)?;
     debug!(
         "crdt delete request: position={}, length={}, base_seq={}",
         position, length, base_seq
@@ -99,6 +109,7 @@ pub async fn replace(
     content: String,
     base_seq: u64,
 ) -> Result<(), String> {
+    ensure_can_write(&state)?;
     let content = normalize_to_lf(content);
     debug!(
         "crdt replace request: position={}, delete_length={}, content_len={}, base_seq={}",

--- a/tauri-app/src-tauri/src/state/mod.rs
+++ b/tauri-app/src-tauri/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_role;
 pub mod appstate;
 pub mod document;
+pub mod roster;
 pub mod ws_state;

--- a/tauri-app/src-tauri/src/state/roster.rs
+++ b/tauri-app/src-tauri/src/state/roster.rs
@@ -74,21 +74,21 @@ impl RosterState {
 
     fn room_state_payload(&self) -> RoomStatePayload {
         let peers = self.peers.lock().unwrap();
-        let mut dtos: Vec<PeerDto> = peers
-            .iter()
-            .map(|(id, entry)| PeerDto {
-                client_id: id.to_string(),
-                username: entry.username.clone(),
-                is_host: entry.is_host,
-                can_write: entry.can_write,
-            })
-            .collect();
-        dtos.sort_by(|a, b| {
-            b.is_host
-                .cmp(&a.is_host)
-                .then_with(|| a.client_id.cmp(&b.client_id))
-        });
-        RoomStatePayload { peers: dtos }
+        let mut entries: Vec<(u64, &PeerEntry)> =
+            peers.iter().map(|(id, entry)| (*id, entry)).collect();
+        // Host first, then numeric id order
+        entries.sort_by_key(|(id, entry)| (!entry.is_host, *id));
+        RoomStatePayload {
+            peers: entries
+                .into_iter()
+                .map(|(id, entry)| PeerDto {
+                    client_id: id.to_string(),
+                    username: entry.username.clone(),
+                    is_host: entry.is_host,
+                    can_write: entry.can_write,
+                })
+                .collect(),
+        }
     }
 }
 
@@ -137,12 +137,7 @@ pub fn resync_own_permission(app: &AppHandle, client_id: u64) {
     let Some(can_write) = state.roster.can_write_of(client_id) else {
         return;
     };
-    let access = if can_write {
-        WriteAccess::Editable
-    } else {
-        WriteAccess::ReadOnly
-    };
-    if state.set_write_access(access) {
+    if state.set_write_access(WriteAccess::from_can_write(can_write)) {
         debug!("roster: own permission resynced after join: can_write={can_write}");
         let _ = app.emit(CAN_WRITE_CHANGED, CanWritePayload { can_write });
     }
@@ -160,11 +155,7 @@ async fn apply_own_permission_if_local(app: &AppHandle, subject: ClientId, can_w
     if local_id != subject {
         return;
     }
-    let access = if can_write {
-        WriteAccess::Editable
-    } else {
-        WriteAccess::ReadOnly
-    };
+    let access = WriteAccess::from_can_write(can_write);
     if state.set_write_access(access) {
         debug!("roster: local write access set to {access:?}");
     }

--- a/tauri-app/src-tauri/src/state/roster.rs
+++ b/tauri-app/src-tauri/src/state/roster.rs
@@ -1,0 +1,177 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crdt_core::types::ClientId;
+use crdt_core::wire::{PeerInfoFrame, PermissionFrame};
+use log::{debug, warn};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::session::session_types::{CanWritePayload, CAN_WRITE_CHANGED, ROOM_STATE_CHANGED};
+use crate::state::app_role::WriteAccess;
+use crate::state::appstate::AppState;
+use crate::state::document::{request, DocOp};
+
+#[derive(Clone)]
+struct PeerEntry {
+    username: String,
+    is_host: bool,
+    can_write: bool,
+}
+
+#[derive(Clone, Serialize)]
+pub struct PeerDto {
+    pub client_id: String,
+    pub username: String,
+    pub is_host: bool,
+    pub can_write: bool,
+}
+
+#[derive(Clone, Serialize)]
+pub struct RoomStatePayload {
+    pub peers: Vec<PeerDto>,
+}
+
+/// The session peer list, fed by gateway-authored peer-info (`0x08`),
+/// permission (`0x07`) and membership (`0x05`) frames. Owned by `AppState` so
+/// permission decisions live in app state; the ws receiver only routes frames
+/// to the `apply_*` functions below.
+#[derive(Default)]
+pub struct RosterState {
+    peers: Mutex<HashMap<u64, PeerEntry>>,
+}
+
+impl RosterState {
+    pub fn clear(&self) {
+        self.peers.lock().unwrap().clear();
+    }
+
+    fn upsert(&self, client_id: u64, entry: PeerEntry) {
+        self.peers.lock().unwrap().insert(client_id, entry);
+    }
+
+    fn set_can_write(&self, client_id: u64, can_write: bool) -> bool {
+        match self.peers.lock().unwrap().get_mut(&client_id) {
+            Some(entry) => {
+                entry.can_write = can_write;
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn remove(&self, client_id: u64) {
+        self.peers.lock().unwrap().remove(&client_id);
+    }
+
+    fn can_write_of(&self, client_id: u64) -> Option<bool> {
+        self.peers
+            .lock()
+            .unwrap()
+            .get(&client_id)
+            .map(|entry| entry.can_write)
+    }
+
+    fn room_state_payload(&self) -> RoomStatePayload {
+        let peers = self.peers.lock().unwrap();
+        let mut dtos: Vec<PeerDto> = peers
+            .iter()
+            .map(|(id, entry)| PeerDto {
+                client_id: id.to_string(),
+                username: entry.username.clone(),
+                is_host: entry.is_host,
+                can_write: entry.can_write,
+            })
+            .collect();
+        dtos.sort_by(|a, b| {
+            b.is_host
+                .cmp(&a.is_host)
+                .then_with(|| a.client_id.cmp(&b.client_id))
+        });
+        RoomStatePayload { peers: dtos }
+    }
+}
+
+/// A gateway roster entry arrived: seed/update the peer list, and adopt the
+/// permission it carries if it describes this client.
+pub async fn apply_peer_info(app: &AppHandle, frame: PeerInfoFrame) {
+    let state = app.state::<AppState>();
+    state.roster.upsert(
+        frame.client_id.value,
+        PeerEntry {
+            username: frame.username.clone(),
+            is_host: frame.is_host,
+            can_write: frame.can_write,
+        },
+    );
+    apply_own_permission_if_local(app, frame.client_id, frame.can_write).await;
+    emit_room_state(app);
+}
+
+pub async fn apply_permission(app: &AppHandle, frame: PermissionFrame) {
+    let state = app.state::<AppState>();
+    if !state
+        .roster
+        .set_can_write(frame.client_id.value, frame.can_write)
+    {
+        warn!(
+            "roster: permission change for unknown peer {}",
+            frame.client_id.value
+        );
+    }
+    apply_own_permission_if_local(app, frame.client_id, frame.can_write).await;
+    emit_room_state(app);
+}
+
+pub fn apply_peer_left(app: &AppHandle, client_id: ClientId) {
+    app.state::<AppState>().roster.remove(client_id.value);
+    emit_room_state(app);
+}
+
+/// Re-applies this client's roster permission to the role. The websocket
+/// connects before `complete_guest` runs, so a peer-info frame can arrive
+/// while the role is still `Starting` and its permission cannot land in the
+/// role yet; `join_session` calls this once the Guest role exists.
+pub fn resync_own_permission(app: &AppHandle, client_id: u64) {
+    let state = app.state::<AppState>();
+    let Some(can_write) = state.roster.can_write_of(client_id) else {
+        return;
+    };
+    let access = if can_write {
+        WriteAccess::Editable
+    } else {
+        WriteAccess::ReadOnly
+    };
+    if state.set_write_access(access) {
+        debug!("roster: own permission resynced after join: can_write={can_write}");
+        let _ = app.emit(CAN_WRITE_CHANGED, CanWritePayload { can_write });
+    }
+}
+
+async fn apply_own_permission_if_local(app: &AppHandle, subject: ClientId, can_write: bool) {
+    let state = app.state::<AppState>();
+    let local_id = match request(&state.doc_tx, |reply| DocOp::GetClientId { reply }).await {
+        Ok(id) => id,
+        Err(e) => {
+            warn!("roster: failed to read local client id: {e}");
+            return;
+        }
+    };
+    if local_id != subject {
+        return;
+    }
+    let access = if can_write {
+        WriteAccess::Editable
+    } else {
+        WriteAccess::ReadOnly
+    };
+    if state.set_write_access(access) {
+        debug!("roster: local write access set to {access:?}");
+    }
+    let _ = app.emit(CAN_WRITE_CHANGED, CanWritePayload { can_write });
+}
+
+fn emit_room_state(app: &AppHandle) {
+    let payload = app.state::<AppState>().roster.room_state_payload();
+    let _ = app.emit(ROOM_STATE_CHANGED, payload);
+}

--- a/tauri-app/src-tauri/src/ws_management/disconnect_handler.rs
+++ b/tauri-app/src-tauri/src/ws_management/disconnect_handler.rs
@@ -16,6 +16,7 @@ pub fn spawn_disconnect_handler(app: AppHandle, rx: oneshot::Receiver<Disconnect
         info!("disconnect handler: received reason={reason:?}");
         let state = app.state::<AppState>();
         state.sync_maintenance.stop_all();
+        state.roster.clear();
         if matches!(reason, DisconnectReason::ConnectionLost)
             && matches!(state.current_role(), AppRole::Host { .. })
         {

--- a/tauri-app/src-tauri/src/ws_management/ws_receiver.rs
+++ b/tauri-app/src-tauri/src/ws_management/ws_receiver.rs
@@ -1,8 +1,9 @@
 use crdt_core::encode_snapshot;
 use crdt_core::store::StateVector;
 use crdt_core::wire::{
-    decode_membership, decode_sv_report, MembershipEvent, CONTROL_SESSION_ENDED,
-    CONTROL_SNAPSHOT_REQUEST, PREFIX_CONTROL, PREFIX_MEMBERSHIP, PREFIX_SV_REPORT,
+    decode_membership, decode_peer_info, decode_permission, decode_sv_report, MembershipEvent,
+    CONTROL_SESSION_ENDED, CONTROL_SNAPSHOT_REQUEST, PREFIX_CONTROL, PREFIX_MEMBERSHIP,
+    PREFIX_PEER_INFO, PREFIX_PERMISSION, PREFIX_SV_REPORT,
 };
 use futures_util::StreamExt;
 use log::{debug, error, info, warn};
@@ -14,6 +15,7 @@ use tokio_tungstenite::tungstenite::Message;
 use crate::state::appstate::AppState;
 use crate::state::document::client::request;
 use crate::state::document::types::DocOp;
+use crate::state::roster;
 use crate::ws_management::ws_types::{DisconnectReason, Stream, WsConnection};
 
 pub async fn receive_loop(
@@ -45,9 +47,11 @@ pub async fn receive_loop(
                         warn!("ws recv: unknown control frame type={:?}; ignoring", other);
                     }
                 },
-                // Host-only coordinator inputs (guests have no gc sender → no-op).
                 Some(PREFIX_MEMBERSHIP) => route_membership(&app, &bytes).await,
+                // Host-only coordinator input (guests have no gc sender → no-op).
                 Some(PREFIX_SV_REPORT) => route_sv_report(&app, &bytes).await,
+                Some(PREFIX_PERMISSION) => route_permission(&app, &bytes).await,
+                Some(PREFIX_PEER_INFO) => route_peer_info(&app, &bytes).await,
                 _ => {
                     debug!("ws receiver binary message (bytes={})", bytes.len());
                     if op_tx.send(bytes.into()).is_err() {
@@ -146,9 +150,24 @@ async fn route_membership(app: &AppHandle, bytes: &[u8]) {
                     .sync_maintenance
                     .peer_left(frame.client_id)
                     .await;
+                roster::apply_peer_left(app, frame.client_id);
             }
         },
         Err(e) => warn!("ws recv: membership decode failed: {e}"),
+    }
+}
+
+async fn route_permission(app: &AppHandle, bytes: &[u8]) {
+    match decode_permission(bytes) {
+        Ok(frame) => roster::apply_permission(app, frame).await,
+        Err(e) => warn!("ws recv: permission decode failed: {e}"),
+    }
+}
+
+async fn route_peer_info(app: &AppHandle, bytes: &[u8]) {
+    match decode_peer_info(bytes) {
+        Ok(frame) => roster::apply_peer_info(app, frame).await,
+        Err(e) => warn!("ws recv: peer-info decode failed: {e}"),
     }
 }
 

--- a/tauri-app/src/App.css
+++ b/tauri-app/src/App.css
@@ -89,6 +89,18 @@ body {
   border-radius: 999px;
 }
 
+.readonly-badge {
+  padding: 3px 11px;
+  border-radius: 999px;
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--amber);
+  background: var(--bg-inset);
+  border: 1px solid rgba(232, 161, 60, 0.35);
+  user-select: none;
+}
+
 .status {
   margin-left: auto;
   padding: 3px 12px;
@@ -703,8 +715,25 @@ body {
 
 .session-actions {
   display: flex;
+  align-items: center;
   gap: 10px;
   margin-top: 8px;
+}
+
+.session-guests-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text-2);
+  cursor: pointer;
+  user-select: none;
+}
+
+.session-guests-edit input {
+  accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .session-btn {

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -9,6 +9,7 @@ import { normalizeToLF, forceModelLF } from "./eol";
 import { UsernameGate } from "./usernameSetup";
 import { FileMenu } from "./components/filemenu/FileMenu";
 import { SessionPanel } from "./components/SessionPanel";
+import { useWritePermission } from "./hooks/useWritePermission";
 import "./App.css";
 
 interface LogEntry {
@@ -79,6 +80,7 @@ function AppContent({ username }: AppContentProps) {
     () => createIpcSenders(enqueueOp),
     [enqueueOp],
   );
+  const canWrite = useWritePermission(editorRef);
 
   // Replaces the whole editor content without echoing ops back to the
   // backend. Normalizes to LF and re-pins the model EOL: on Windows,
@@ -258,6 +260,14 @@ function AppContent({ username }: AppContentProps) {
           onSaved={() => setDirty(false)}
         />
         {username && <span className="toolbar-username">{username}</span>}
+        {!canWrite && (
+          <span
+            className="readonly-badge"
+            title="The host has made you read-only"
+          >
+            🔒 read-only
+          </span>
+        )}
         {isDevFeaturesEnabled && (
           <button
             onClick={() => void toggleLogging()}

--- a/tauri-app/src/components/PeersPanel.css
+++ b/tauri-app/src/components/PeersPanel.css
@@ -1,0 +1,263 @@
+/* ── Peers panel toggle button ─────────────────────────── */
+
+.peers-panel-toggle {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 900;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-raised);
+  color: var(--text-2);
+  font-size: 17px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    transform 0.15s;
+  box-shadow: var(--shadow-pop);
+}
+
+.peers-panel-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-1);
+  border-color: var(--border-strong);
+  transform: scale(1.06);
+}
+
+.peers-panel-toggle .badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  background: var(--accent);
+  color: #fff;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+/* ── Panel ─────────────────────────────────────────────── */
+
+.peers-panel {
+  position: fixed;
+  right: 16px;
+  bottom: 64px;
+  z-index: 901;
+  width: 280px;
+  max-height: 360px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-pop);
+  font-family: var(--font-ui);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: peers-panel-in 0.15s ease-out;
+}
+
+@keyframes peers-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.peers-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.peers-panel-header h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-1);
+  letter-spacing: 0.02em;
+}
+
+.peers-panel-header .close-btn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  font-size: 15px;
+  padding: 2px;
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s;
+}
+
+.peers-panel-header .close-btn:hover {
+  color: var(--text-1);
+}
+
+/* ── Peer list ─────────────────────────────────────────── */
+
+.peers-list {
+  overflow-y: auto;
+  padding: 6px 0;
+  flex: 1;
+}
+
+.peer-row {
+  display: flex;
+  align-items: center;
+  padding: 7px 14px;
+  gap: 10px;
+  transition: background 0.12s;
+}
+
+.peer-row:hover {
+  background: var(--bg-hover);
+}
+
+.peer-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.peer-avatar.host {
+  background: var(--amber);
+}
+
+.peer-avatar.guest {
+  background: var(--accent);
+}
+
+.peer-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.peer-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.peer-role {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  margin-top: 1px;
+}
+
+.peer-role.host-role {
+  color: var(--amber);
+}
+
+/* ── Permission toggle ─────────────────────────────────── */
+
+.perm-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.perm-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.perm-label.write {
+  color: var(--green);
+}
+
+.perm-label.readonly {
+  color: var(--text-3);
+}
+
+.perm-toggle {
+  flex-shrink: 0;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.2s;
+  padding: 0;
+}
+
+.perm-toggle.can-write {
+  background: var(--green);
+}
+
+.perm-toggle.read-only {
+  background: var(--bg-hover);
+}
+
+.perm-toggle .knob {
+  position: absolute;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transition: left 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.perm-toggle.can-write .knob {
+  left: 18px;
+}
+
+.perm-toggle.read-only .knob {
+  left: 2px;
+}
+
+.perm-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.perm-badge.write {
+  background: rgba(67, 195, 131, 0.15);
+  color: var(--green);
+}
+
+.perm-badge.readonly {
+  background: var(--bg-inset);
+  color: var(--text-3);
+}

--- a/tauri-app/src/components/PeersPanel.tsx
+++ b/tauri-app/src/components/PeersPanel.tsx
@@ -1,0 +1,125 @@
+import { useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { RoomState, PeerInfo } from "../hooks/useRoomState";
+import "./PeersPanel.css";
+
+interface PeersPanelProps {
+  roomState: RoomState | null;
+  /** Whether the local user hosts the session (only hosts see the toggles). */
+  isHost: boolean;
+}
+
+/**
+ * Floating peer list for an active session. Every member sees who is in the
+ * room and their write permission; the host can grant/revoke write access
+ * per guest. Toggles are optimistic-free: the switch flips only when the
+ * gateway's authoritative room-state echo arrives.
+ */
+export function PeersPanel({ roomState, isHost }: PeersPanelProps) {
+  const [open, setOpen] = useState(false);
+
+  const togglePermission = useCallback(async (peer: PeerInfo) => {
+    try {
+      await invoke("set_peer_permission", {
+        targetClientId: peer.client_id,
+        canWrite: !peer.can_write,
+      });
+    } catch (e) {
+      console.error("Failed to set peer permission:", e);
+    }
+  }, []);
+
+  if (!roomState) return null;
+
+  // The backend emits peers already sorted (host first, then by id).
+  const peers = roomState.peers;
+
+  return (
+    <>
+      <button
+        className="peers-panel-toggle"
+        onClick={() => setOpen((prev) => !prev)}
+        title="Peers"
+      >
+        👥
+        {peers.length > 0 && <span className="badge">{peers.length}</span>}
+      </button>
+
+      {open && (
+        <div className="peers-panel">
+          <div className="peers-panel-header">
+            <h3>Peers ({peers.length})</h3>
+            <button
+              className="close-btn"
+              onClick={() => setOpen(false)}
+              title="Close"
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="peers-list">
+            {peers.map((peer) => (
+              <PeerRow
+                key={peer.client_id}
+                peer={peer}
+                isHost={isHost}
+                onToggle={togglePermission}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+interface PeerRowProps {
+  peer: PeerInfo;
+  isHost: boolean;
+  onToggle: (peer: PeerInfo) => Promise<void>;
+}
+
+function PeerRow({ peer, isHost, onToggle }: PeerRowProps) {
+  const displayName = peer.username || `Client ${peer.client_id.slice(0, 6)}`;
+  const initial = displayName.charAt(0).toUpperCase();
+  const showToggle = isHost && !peer.is_host;
+
+  return (
+    <div className="peer-row">
+      <div className={`peer-avatar ${peer.is_host ? "host" : "guest"}`}>
+        {initial}
+      </div>
+
+      <div className="peer-info">
+        <div className="peer-name">{displayName}</div>
+        <div className={`peer-role ${peer.is_host ? "host-role" : ""}`}>
+          {peer.is_host ? "Host" : "Guest"}
+        </div>
+      </div>
+
+      {showToggle ? (
+        <div className="perm-control">
+          <span
+            className={`perm-label ${peer.can_write ? "write" : "readonly"}`}
+          >
+            {peer.can_write ? "Can Edit" : "Read Only"}
+          </span>
+          <button
+            className={`perm-toggle ${peer.can_write ? "can-write" : "read-only"}`}
+            onClick={() => void onToggle(peer)}
+            title={
+              peer.can_write ? "Revoke write access" : "Grant write access"
+            }
+          >
+            <span className="knob" />
+          </button>
+        </div>
+      ) : (
+        <span className={`perm-badge ${peer.can_write ? "write" : "readonly"}`}>
+          {peer.can_write ? "Can Edit" : "Read Only"}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/tauri-app/src/components/SessionPanel.tsx
+++ b/tauri-app/src/components/SessionPanel.tsx
@@ -5,7 +5,9 @@ import {
   type SessionNotice,
 } from "../hooks/useSessionEvents";
 import { useMetrics } from "../hooks/useMetrics";
+import { useRoomState } from "../hooks/useRoomState";
 import { MetricsPopup } from "./MetricsPopup";
+import { PeersPanel } from "./PeersPanel";
 import { SaveBeforeSessionModal } from "./SaveBeforeSessionModal";
 import { JoinModal } from "./JoinModal";
 
@@ -49,14 +51,17 @@ export function SessionPanel({
 
   const { gatewayFields, gatewayUnavailable, tunnelFields, tunnelUnavailable } =
     useMetrics(sessionStatus, processesRunning);
+  const { roomState, clearRoomState } = useRoomState();
 
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
   const [showJoinModal, setShowJoinModal] = useState(false);
   const [showSavePrompt, setShowSavePrompt] = useState(false);
   const [showGatewayMetrics, setShowGatewayMetrics] = useState(false);
   const [showTunnelMetrics, setShowTunnelMetrics] = useState(false);
+  const [guestsCanWrite, setGuestsCanWrite] = useState(false);
 
   const isHost = sessionStatus === "host";
+  const inSession = isHost || sessionStatus === "guest";
 
   useEffect(() => {
     if (!isHost) {
@@ -78,13 +83,13 @@ export function SessionPanel({
   const handleHost = useCallback(async () => {
     setSessionBusy(true);
     try {
-      await invoke("host_session");
+      await invoke("host_session", { guestsCanWrite });
     } catch (err) {
       setSessionStatus("error: " + String(err));
     } finally {
       setSessionBusy(false);
     }
-  }, [setSessionBusy, setSessionStatus]);
+  }, [guestsCanWrite, setSessionBusy, setSessionStatus]);
 
   const startJoin = useCallback(async () => {
     await resetDocAndEditor();
@@ -126,13 +131,19 @@ export function SessionPanel({
     if (sessionBusy) return;
     setSessionBusy(true);
     void invoke("end_session")
-      .then(() => applyIdleSessionState())
+      .then(() => {
+        applyIdleSessionState();
+        clearRoomState();
+      })
       .finally(() => setSessionBusy(false));
-  }, [applyIdleSessionState, sessionBusy, setSessionBusy]);
+  }, [applyIdleSessionState, clearRoomState, sessionBusy, setSessionBusy]);
 
   const handleLeaveSession = useCallback(() => {
-    void invoke("leave_session").then(() => applyIdleSessionState());
-  }, [applyIdleSessionState]);
+    void invoke("leave_session").then(() => {
+      applyIdleSessionState();
+      clearRoomState();
+    });
+  }, [applyIdleSessionState, clearRoomState]);
 
   const handleKillProcesses = useCallback(() => {
     void invoke("kill_host_processes").then(() =>
@@ -238,6 +249,19 @@ export function SessionPanel({
               🔗 Join Session
             </button>
           )}
+          {!sessionBusy && (
+            <label
+              className="session-guests-edit"
+              title="Whether joining guests may edit right away. You can change each guest's access later from the peers panel."
+            >
+              <input
+                type="checkbox"
+                checked={guestsCanWrite}
+                onChange={(e) => setGuestsCanWrite(e.target.checked)}
+              />
+              Guests can edit
+            </label>
+          )}
         </div>
       )}
       {sessionNotice && (
@@ -291,6 +315,7 @@ export function SessionPanel({
           onCancel={() => setShowJoinModal(false)}
         />
       )}
+      {inSession && <PeersPanel roomState={roomState} isHost={isHost} />}
     </div>
   );
 }

--- a/tauri-app/src/hooks/useRoomState.ts
+++ b/tauri-app/src/hooks/useRoomState.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { listen } from "@tauri-apps/api/event";
+import { useState, useCallback } from "react";
+import { useTauriEvents } from "./useTauriEvents";
 
 /** client_id is a string: ids are random u64s and JS numbers lose precision. */
 export interface PeerInfo {
@@ -22,30 +22,16 @@ export function useRoomState() {
   const [roomState, setRoomState] = useState<RoomState | null>(null);
   const clearRoomState = useCallback(() => setRoomState(null), []);
 
-  useEffect(() => {
-    const unlisten: (() => void)[] = [];
-    let cancelled = false;
-
-    void (async () => {
-      const register = (fn: () => void) => {
-        if (cancelled) fn();
-        else unlisten.push(fn);
-      };
-
-      register(
-        await listen<RoomState>("session://room-state", (e) => {
-          setRoomState(e.payload);
-        }),
-      );
-      register(await listen("session://session-ended", clearRoomState));
-      register(await listen("session://disconnected", clearRoomState));
-    })();
-
-    return () => {
-      cancelled = true;
-      unlisten.forEach((fn) => fn());
-    };
-  }, [clearRoomState]);
+  useTauriEvents(
+    useCallback(
+      (on) => {
+        on<RoomState>("session://room-state", setRoomState);
+        on("session://session-ended", clearRoomState);
+        on("session://disconnected", clearRoomState);
+      },
+      [clearRoomState],
+    ),
+  );
 
   return { roomState, clearRoomState };
 }

--- a/tauri-app/src/hooks/useRoomState.ts
+++ b/tauri-app/src/hooks/useRoomState.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/** client_id is a string: ids are random u64s and JS numbers lose precision. */
+export interface PeerInfo {
+  client_id: string;
+  username: string;
+  is_host: boolean;
+  can_write: boolean;
+}
+
+export interface RoomState {
+  peers: PeerInfo[];
+}
+
+/**
+ * Live session peer list, fed by the backend's `session://room-state` events
+ * (which mirror the gateway's roster). Cleared automatically when the session
+ * ends remotely; call `clearRoomState` on locally initiated end/leave.
+ */
+export function useRoomState() {
+  const [roomState, setRoomState] = useState<RoomState | null>(null);
+  const clearRoomState = useCallback(() => setRoomState(null), []);
+
+  useEffect(() => {
+    const unlisten: (() => void)[] = [];
+    let cancelled = false;
+
+    void (async () => {
+      const register = (fn: () => void) => {
+        if (cancelled) fn();
+        else unlisten.push(fn);
+      };
+
+      register(
+        await listen<RoomState>("session://room-state", (e) => {
+          setRoomState(e.payload);
+        }),
+      );
+      register(await listen("session://session-ended", clearRoomState));
+      register(await listen("session://disconnected", clearRoomState));
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten.forEach((fn) => fn());
+    };
+  }, [clearRoomState]);
+
+  return { roomState, clearRoomState };
+}

--- a/tauri-app/src/hooks/useTauriEvents.ts
+++ b/tauri-app/src/hooks/useTauriEvents.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+type Registrar = <T>(event: string, handler: (payload: T) => void) => void;
+
+export function useTauriEvents(subscribe: (on: Registrar) => void) {
+  useEffect(() => {
+    const unlisten: (() => void)[] = [];
+    let cancelled = false;
+
+    subscribe(<T>(event: string, handler: (payload: T) => void) => {
+      void listen<T>(event, (e) => handler(e.payload)).then((fn) => {
+        if (cancelled) fn();
+        else unlisten.push(fn);
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten.forEach((fn) => fn());
+    };
+  }, [subscribe]);
+}

--- a/tauri-app/src/hooks/useWritePermission.ts
+++ b/tauri-app/src/hooks/useWritePermission.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect, type MutableRefObject } from "react";
-import { listen } from "@tauri-apps/api/event";
+import { useState, useEffect, useCallback, type MutableRefObject } from "react";
 import type { editor } from "monaco-editor";
+import { useTauriEvents } from "./useTauriEvents";
 
 interface CanWritePayload {
   can_write: boolean;
@@ -17,32 +17,15 @@ export function useWritePermission(
 ) {
   const [canWrite, setCanWrite] = useState(true);
 
-  useEffect(() => {
-    const unlisten: (() => void)[] = [];
-    let cancelled = false;
-
-    void (async () => {
-      const register = (fn: () => void) => {
-        if (cancelled) fn();
-        else unlisten.push(fn);
-      };
-
-      register(
-        await listen<CanWritePayload>("session://can-write", (e) => {
-          setCanWrite(e.payload.can_write);
-        }),
+  useTauriEvents(
+    useCallback((on) => {
+      on<CanWritePayload>("session://can-write", (payload) =>
+        setCanWrite(payload.can_write),
       );
-      register(
-        await listen("session://session-ended", () => setCanWrite(true)),
-      );
-      register(await listen("session://disconnected", () => setCanWrite(true)));
-    })();
-
-    return () => {
-      cancelled = true;
-      unlisten.forEach((fn) => fn());
-    };
-  }, []);
+      on("session://session-ended", () => setCanWrite(true));
+      on("session://disconnected", () => setCanWrite(true));
+    }, []),
+  );
 
   useEffect(() => {
     editorRef.current?.updateOptions({ readOnly: !canWrite });

--- a/tauri-app/src/hooks/useWritePermission.ts
+++ b/tauri-app/src/hooks/useWritePermission.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, type MutableRefObject } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { editor } from "monaco-editor";
+
+interface CanWritePayload {
+  can_write: boolean;
+}
+
+/**
+ * Tracks the local user's write permission (host-granted for guests) and
+ * mirrors it into Monaco's readOnly option. The backend command guard is the
+ * authority; this only keeps the UI honest. Editing is re-enabled when the
+ * session ends in any way.
+ */
+export function useWritePermission(
+  editorRef: MutableRefObject<editor.IStandaloneCodeEditor | null>,
+) {
+  const [canWrite, setCanWrite] = useState(true);
+
+  useEffect(() => {
+    const unlisten: (() => void)[] = [];
+    let cancelled = false;
+
+    void (async () => {
+      const register = (fn: () => void) => {
+        if (cancelled) fn();
+        else unlisten.push(fn);
+      };
+
+      register(
+        await listen<CanWritePayload>("session://can-write", (e) => {
+          setCanWrite(e.payload.can_write);
+        }),
+      );
+      register(
+        await listen("session://session-ended", () => setCanWrite(true)),
+      );
+      register(await listen("session://disconnected", () => setCanWrite(true)));
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten.forEach((fn) => fn());
+    };
+  }, []);
+
+  useEffect(() => {
+    editorRef.current?.updateOptions({ readOnly: !canWrite });
+  }, [canWrite, editorRef]);
+
+  return canWrite;
+}

--- a/tauri-app/src/remoteChangeListener.ts
+++ b/tauri-app/src/remoteChangeListener.ts
@@ -41,6 +41,23 @@ interface UseRemoteChangeListenerArgs {
   onDocChanged: () => void;
 }
 
+function executeRemoteEdit(
+  ed: editor.IStandaloneCodeEditor,
+  edits: editor.IIdentifiedSingleEditOperation[],
+) {
+  const wasReadOnly = ed.getRawOptions().readOnly === true;
+  if (wasReadOnly) {
+    ed.updateOptions({ readOnly: false });
+  }
+  try {
+    ed.executeEdits("crdt", edits);
+  } finally {
+    if (wasReadOnly) {
+      ed.updateOptions({ readOnly: true });
+    }
+  }
+}
+
 export function useRemoteChangeListener({
   editorRef,
   monacoRef,
@@ -77,7 +94,7 @@ export function useRemoteChangeListener({
       try {
         if (change.type === "insert") {
           const pos = model.getPositionAt(change.position);
-          ed.executeEdits("crdt", [
+          executeRemoteEdit(ed, [
             {
               range: new mn.Range(
                 pos.lineNumber,
@@ -103,7 +120,7 @@ export function useRemoteChangeListener({
         } else {
           const startPos = model.getPositionAt(change.position);
           const endPos = model.getPositionAt(change.position + change.length);
-          ed.executeEdits("crdt", [
+          executeRemoteEdit(ed, [
             {
               range: new mn.Range(
                 startPos.lineNumber,


### PR DESCRIPTION
- new 0x07 permission and 0x08 peer-info wire frames
- gateway enforces roles: first joiner is host, drops ops from read-only guests
- host toggle for default guest write access, per-peer grant/revoke in peers panel
- guest side gates insert/delete/replace and mirrors readOnly into monaco
closes #27